### PR TITLE
Default DEBUG to True for development.

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -1,5 +1,5 @@
 #General/Misc Config
-DEBUG: False
+DEBUG: True
 LOGLEVEL: 'INFO'
 UPLOADS_DEFAULT_DEST: "/tmp"
 


### PR DESCRIPTION
This fixes #6.

Since `DEBUG: False` is already specified in the sample production config given in the README, I figure the non-production one can default to `True`, though existing deploys should probably ensure they explicitly set `DEBUG: False` in their `local_config.yml` before this is merged!