### PR TITLE
Add a trivial unit test suite.

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,3 +119,16 @@ You'll need to populate the resulting `.po` file for each locale in
 To generate the `.mo` file used in actual translation.  Successive runs of the
 script won't destroy any data in the `.po` file, which is kept in version
 control.
+
+### Unit Testing
+
+To run the unit tests, simply run:
+
+    ./nosetests.sh
+
+This just executes [`nosetests`][] inside the web application's Docker
+container.
+
+Tests are located in `app/tests`. Please feel free to add more!
+
+  [`nosetests`]: https://nose.readthedocs.org/en/latest/usage.html

--- a/app/tests/test_models.py
+++ b/app/tests/test_models.py
@@ -1,0 +1,11 @@
+from nose.tools import eq_
+
+from .. import models
+
+def test_users_only_display_in_search_if_they_have_first_and_last_name():
+    user = models.User()
+    eq_(user.display_in_search, False)
+    user.first_name = "John"
+    eq_(user.display_in_search, False)
+    user.last_name = "Doe"
+    eq_(user.display_in_search, True)

--- a/nosetests.sh
+++ b/nosetests.sh
@@ -1,0 +1,3 @@
+#!/bin/bash -e
+
+docker-compose run app nosetests -w /noi $@


### PR DESCRIPTION
This adds the simplest possible unit test infrastructure. While I think it may *technically* establish a connection to the database, unless I'm mistaken about how SQLAlchemy models work, it shouldn't actually *do* anything with that connection--I'd like to save setup/teardown of a test DB for a later PR.
