### PR TITLE
Fix ambiguous docker volume warnings.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ app:
           #- redis
     volumes:
         - .:/noi
-        - migrations:/migrations
+        - ./migrations:/migrations
     environment:
         - NOI_ENVIRONMENT # unless production, assumed "development"
 db:
@@ -14,7 +14,7 @@ db:
 web:
     image: nginx
     volumes:
-        - conf/:/etc/nginx/conf.d/
+        - ./conf/:/etc/nginx/conf.d/
         - ./app/static:/noi/app/static
         - .keys:/etc/ssl/certs
     links:


### PR DESCRIPTION
Here's an example warning this suppresses:

> Warning: the mapping "conf/:/etc/nginx/conf.d/" in the volumes
> config for service "web" is ambiguous. In a future version of Docker,
> it will designate a "named" volume (see
> https://github.com/docker/docker/pull/14242). To prevent unexpected
> behaviour, change it to "./conf/:/etc/nginx/conf.d/"

This warning appears on Docker 1.8.2.