### PR TITLE
Make login_required work again

### DIFF
--- a/app/factory.py
+++ b/app/factory.py
@@ -174,6 +174,10 @@ def create_app(config=None): #pylint: disable=too-many-statements
     security.init_app(app, datastore=user_datastore,
                       confirm_register_form=EmailRestrictRegisterForm)
 
+    # This forces any "lazy strings" like those returned by
+    # lazy_gettext() to be evaluated.
+    app.login_manager.localize_callback = lambda x: unicode(x)
+
     db.init_app(app)
     alchemydumps.init_app(app, db)
     #login_manager.init_app(app)

--- a/app/factory.py
+++ b/app/factory.py
@@ -176,7 +176,7 @@ def create_app(config=None): #pylint: disable=too-many-statements
 
     # This forces any "lazy strings" like those returned by
     # lazy_gettext() to be evaluated.
-    app.login_manager.localize_callback = lambda x: unicode(x)
+    app.login_manager.localize_callback = unicode
 
     db.init_app(app)
     alchemydumps.init_app(app, db)


### PR DESCRIPTION
This is a potential fix for #33.

An alternative, perhaps more "proper" fix would be to not wrap flask-login flash message strings in `lazy_gettext` and to instead set `app.login_manager.localize_callback = gettext`. However, since I'm not entirely sure what such strings are, and since `unicode()` will just be a no-op if the argument is already unicode, I opted for this more expedient solution.