### PR TITLE
Add "Most Complete Profiles" section to activity feed

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -257,6 +257,8 @@ class User(db.Model, UserMixin, DeploymentMixin): #pylint: disable=no-init,too-f
             order_by(count.desc()).\
             limit(limit).all()
         )
+        if not user_id_skill_counts:
+            return []
         users = db.session.query(User).\
                 filter(User.id.in_(user_id_skill_counts.keys())).all()
         for user in users:

--- a/app/templates/activity.html
+++ b/app/templates/activity.html
@@ -53,4 +53,18 @@
 {% endfor %}
 </ul>
 
+<h3>Most Complete Profiles</h3>
+
+<ol>
+  {% for ranked_user in most_complete_profiles %}
+    <li>
+      <p>{{ user_link(ranked_user) }}</p>
+      <small>
+	{{ ranked_user.skill_count }} /
+	{{ QUESTIONS_BY_ID.keys()|length }} Skills
+      </small>
+    </li>
+  {% endfor %}
+</ol>
+
 {% endblock %}

--- a/app/tests/test_models.py
+++ b/app/tests/test_models.py
@@ -89,6 +89,10 @@ class UserSkillDbTests(DbTestCase):
           .filter(models.User.email=='sly@stone-less-knowledgeable.com')\
           .one()
 
+    def test_get_most_complete_profiles_works(self):
+        users = models.User.get_most_complete_profiles()
+        self.assertEqual(users[-1].email, 'sly@stone-less-knowledgeable.com')
+
     def test_questionnaire_progress_works(self):
         progress = self.sly_less.questionnaire_progress
         self.assertEqual(progress['opendata']['answered'], 4)

--- a/app/views.py
+++ b/app/views.py
@@ -269,7 +269,8 @@ def activity():
     return render_template('activity.html', **{
         'user': current_user,
         'events': events,
-        'shared_message_form': shared_message_form
+        'shared_message_form': shared_message_form,
+        'most_complete_profiles': User.get_most_complete_profiles(limit=5)
     })
 
 @views.route('/feedback')


### PR DESCRIPTION
This adds a `get_most_complete_profiles` class method to `User`, which returns a list of the users with the most complete profiles.

It's based on the code for `User.nearest_neighbors`, but one concern I have about that method (and consequently this one) is that it doesn't seem to do any filtering of users by deployment... Shouldn't that be taken into account for all methods like this?