### PR TITLE
Localize login/security form labels

### DIFF
--- a/app/factory.py
+++ b/app/factory.py
@@ -14,7 +14,9 @@ from app import (csrf, cache, mail, bcrypt, s3, assets, security,
                  babel, celery, alchemydumps,
                  QUESTIONNAIRES, NOI_COLORS, LEVELS, ORG_TYPES, QUESTIONS_BY_ID)
 from app.config.schedule import CELERYBEAT_SCHEDULE
-from app.forms import EmailRestrictRegisterForm
+from app.forms import (NOIConfirmRegisterForm, NOIForgotPasswordForm,
+                       NOIResetPasswordForm, NOIChangePasswordForm,
+                       NOISendConfirmationForm, NOIRegisterForm)
 from app.models import db, User, Role
 from app.views import views
 
@@ -172,7 +174,12 @@ def create_app(config=None): #pylint: disable=too-many-statements
     # Setup Flask-Security
     user_datastore = DeploySQLAlchemyUserDatastore(db, User, Role)
     security.init_app(app, datastore=user_datastore,
-                      confirm_register_form=EmailRestrictRegisterForm)
+                      register_form=NOIRegisterForm,
+                      confirm_register_form=NOIConfirmRegisterForm,
+                      forgot_password_form=NOIForgotPasswordForm,
+                      reset_password_form=NOIResetPasswordForm,
+                      change_password_form=NOIChangePasswordForm,
+                      send_confirmation_form=NOISendConfirmationForm)
 
     # This forces any "lazy strings" like those returned by
     # lazy_gettext() to be evaluated.

--- a/app/forms.py
+++ b/app/forms.py
@@ -152,8 +152,7 @@ class NOIRegisterForm(RegisterForm):
     '''
     Localizeable version of Flask-Security's RegisterForm
     '''
-    first_name = StringField(lazy_gettext('First Name'))
-    last_name = StringField(lazy_gettext('Last Name'))
+
     email = StringField(
         lazy_gettext('Email'),
         validators=[email_required, email_validator, unique_user_email])

--- a/app/forms.py
+++ b/app/forms.py
@@ -8,10 +8,16 @@ from app.models import User
 from flask import current_app
 from flask_wtf import Form
 from flask_wtf.file import FileField, FileAllowed
-from flask_security.forms import ConfirmRegisterForm
+from flask_security.forms import (LoginForm, RegisterForm, ConfirmRegisterForm,
+                                  ForgotPasswordForm, ChangePasswordForm,
+                                  ResetPasswordForm,
+                                  SendConfirmationForm, email_required,
+                                  email_validator, unique_user_email,
+                                  password_required, password_length, EqualTo)
 
 from flask_babel import lazy_gettext
 from wtforms_alchemy import model_form_factory, CountryField
+from wtforms import StringField, PasswordField, BooleanField, SubmitField
 from wtforms.fields import SelectMultipleField, TextField, TextAreaField
 from wtforms.widgets import Select
 from wtforms.validators import ValidationError
@@ -117,7 +123,47 @@ class SearchForm(Form):
     fulltext = TextField()
 
 
-class EmailRestrictRegisterForm(ConfirmRegisterForm):
+class NOISendConfirmationForm(SendConfirmationForm):
+    '''
+    Localizeable version of Flask-Security's SendConfirmationForm
+    '''
+    submit = SubmitField(lazy_gettext('Resend Confirmation Instructions'))
+
+
+class NOIForgotPasswordForm(ForgotPasswordForm):
+    '''
+    Localizeable version of Flask-Security's ForgotPasswordForm
+    '''
+    submit = SubmitField(lazy_gettext('Recover Password'))
+
+
+class NOILoginForm(LoginForm):
+    '''
+    Localizeable version of Flask-Security's LoginForm
+    '''
+
+    email = StringField(lazy_gettext('Email'))
+    password = PasswordField(lazy_gettext('Password'))
+    remember = BooleanField(lazy_gettext('Remember Me'))
+    submit = SubmitField(lazy_gettext('Log in'))
+
+
+class NOIRegisterForm(RegisterForm):
+    '''
+    Localizeable version of Flask-Security's RegisterForm
+    '''
+    first_name = StringField(lazy_gettext('First Name'))
+    last_name = StringField(lazy_gettext('Last Name'))
+    email = StringField(
+        lazy_gettext('Email'),
+        validators=[email_required, email_validator, unique_user_email])
+    password = PasswordField(
+        lazy_gettext('Password'), validators=[password_required,
+                                              password_length])
+    submit = SubmitField(lazy_gettext('Sign up'))
+
+
+class NOIConfirmRegisterForm(ConfirmRegisterForm):
     '''
     Custom registration form that limits emails to a certain domain.
     '''
@@ -143,3 +189,27 @@ class EmailRestrictRegisterForm(ConfirmRegisterForm):
                 {'value': value,
                  'explanation': lazy_gettext(current_app.config.get('EMAIL_EXPLANATION'))}
             ))
+
+
+class NOIResetPasswordForm(ResetPasswordForm):
+    '''
+    Localizeable ResetPasswordForm
+    '''
+
+    submit = SubmitField(lazy_gettext('Reset Password'))
+
+
+class NOIChangePasswordForm(ChangePasswordForm):
+    '''
+    Localizeable ChangePasswordForm
+    '''
+
+    new_password = PasswordField(
+        lazy_gettext('New Password'),
+        validators=[password_required, password_length])
+
+    new_password_confirm = PasswordField(
+        lazy_gettext('Retype Password'),
+        validators=[EqualTo('new_password', message='RETYPE_PASSWORD_MISMATCH')])
+
+    submit = SubmitField(lazy_gettext('Change Password'))


### PR DESCRIPTION
Because of flask-security's lack of i18n, and because it's not possible to monkeypatch-in i18n support for its built-in form labels, we need to subclass every built-in form. Ugh!

Almost all this work was done by @talos in https://github.com/GovLab/noi2/commit/569eeb40ba1a7021f790c815117e0f9c282b2b4f, with the exception that I added a missing `password_length` validator to the `NOIRegisterForm`.