### PR TITLE
Use tojson filter when gettext is used in script tags

### DIFF
--- a/app/templates/feedback.html
+++ b/app/templates/feedback.html
@@ -26,7 +26,7 @@
     "project_id": {{ config.contact_form_id }},
     "afterSubmit": {
       "method": "page",
-      "html": "<p>{{ gettext('Thanks for submitting our form!') }}</p>"
+      "html": "<p>" + {{ gettext('Thanks for submitting our form!')|tojson }} + "</p>"
     }
   });
 </script>

--- a/app/templates/my-profile.html
+++ b/app/templates/my-profile.html
@@ -203,7 +203,7 @@ $( document ).ready(function() {
           if (this.files[0]) {
             if (this.files[0].size > 1000 * 1000) {
               $(this).val('');
-              alert({{ gettext('Sorry, that file is too big.  Please choose a smaller one.') }});
+              alert({{ gettext('Sorry, that file is too big.  Please choose a smaller one.')|tojson }});
             }
           }
         }


### PR DESCRIPTION
This uses the [`tojson`](http://flask.pocoo.org/docs/0.10/templating/#standard-filters) filter to properly escape `gettext` output when it's used within script tags.

So far the only places I know that need this are from examining f4113d7f5f8db81cf70299eecaa1e4177f5410a4:
* Within `feedback.html` (this page *is* potentially still broken due to #47, though). 
* Within `my-profile.html` (#44).
