### PR TITLE
Require first and last name in user profile.

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -83,6 +83,14 @@ class UserForm(ModelForm):  #pylint: disable=no-init,too-few-public-methods
         only = ['first_name', 'last_name', 'position', 'organization',
                 'organization_type', 'city', 'country', 'projects',
                 'has_picture']
+        field_args = {
+            'first_name': {
+                'validators': [Required()]
+            },
+            'last_name': {
+                'validators': [Required()]
+            },
+        }
 
     picture = FileField(
         label=lazy_gettext('User Picture'),

--- a/app/tests/test_views.py
+++ b/app/tests/test_views.py
@@ -170,17 +170,28 @@ class MyProfileTests(ViewTestCase):
         self.login()
         self.assert200(self.client.get('/me'))
 
+    def test_invalid_form_shows_errors(self):
+        self.login()
+        res = self.client.post('/me', data={
+            'first_name': '',
+            'expertise_domain_names': 'Agriculture',
+        })
+        self.assertEqual(self.last_created_user.expertise_domain_names, [])
+        assert "please correct errors" in res.data
+
     def test_updating_profile_works(self):
         self.login()
         user = self.last_created_user
         res = self.client.post('/me', data={
             'first_name': 'John2',
+            'last_name': 'Doe2',
             'expertise_domain_names': 'Agriculture',
             'locales': 'af'
         }, follow_redirects=True)
         assert 'Your profile has been saved' in res.data
         self.assert200(res)
         self.assertEqual(user.first_name, 'John2')
+        self.assertEqual(user.last_name, 'Doe2')
         self.assertEqual(user.expertise_domain_names, ['Agriculture'])
         self.assertEqual(len(user.locales), 1)
         self.assertEqual(str(user.locales[0]), 'af')


### PR DESCRIPTION
This fixes #50. Also, since it's now actually possible for form validation to fail in the user profile page, I added a test for it.