### PR TITLE
Make flask-security internationalize properly w/ interpolated strings.

### DIFF
--- a/app/factory.py
+++ b/app/factory.py
@@ -6,7 +6,7 @@ Creates the app
 
 from flask import Flask, current_app
 #from flask.ext.uploads import configure_uploads
-from flask_babel import lazy_gettext
+from flask_babel import lazy_gettext as original_lazy_gettext
 from flask_security import SQLAlchemyUserDatastore, user_registered
 from flask_security.utils import get_identity_attributes
 
@@ -25,6 +25,19 @@ from sqlalchemy.orm.exc import NoResultFound
 from celery import Task
 from slugify import slugify
 import yaml
+
+def lazy_gettext(string):
+    '''
+    Like lazy_gettext, but doesn't interpolate strings. This is
+    required for integration with flask_security, which does its
+    own string interpolation but doesn't support i18n.
+
+    For more information, see: https://github.com/GovLab/noi2/issues/41
+    '''
+
+    return original_lazy_gettext(string,
+                                 email='%(email)s',
+                                 within='%(within)s')
 
 #print 'field_label' + str(flask_security.forms.get_form_field_label)
 #flask_security.forms.get_form_field_label = lambda: 'foo'

--- a/app/factory.py
+++ b/app/factory.py
@@ -6,7 +6,6 @@ Creates the app
 
 from flask import Flask, current_app
 #from flask.ext.uploads import configure_uploads
-from flask_babel import lazy_gettext as original_lazy_gettext
 from flask_security import SQLAlchemyUserDatastore, user_registered
 from flask_security.utils import get_identity_attributes
 
@@ -25,19 +24,26 @@ from sqlalchemy.orm.exc import NoResultFound
 from celery import Task
 from slugify import slugify
 import yaml
+import flask_babel
 
 def lazy_gettext(string):
     '''
-    Like lazy_gettext, but doesn't interpolate strings. This is
+    Like flask_babel's lazy_gettext, but doesn't interpolate strings. This is
     required for integration with flask_security, which does its
     own string interpolation but doesn't support i18n.
 
     For more information, see: https://github.com/GovLab/noi2/issues/41
     '''
 
-    return original_lazy_gettext(string,
-                                 email='%(email)s',
-                                 within='%(within)s')
+    from speaklater import make_lazy_string
+
+    def gettext_no_interpolate(string):
+        t = flask_babel.get_translations()
+        if t is None:
+            return string
+        return t.ugettext(string)
+
+    return make_lazy_string(gettext_no_interpolate, string)
 
 #print 'field_label' + str(flask_security.forms.get_form_field_label)
 #flask_security.forms.get_form_field_label = lambda: 'foo'

--- a/app/tests/test_views.py
+++ b/app/tests/test_views.py
@@ -222,6 +222,15 @@ class ViewTests(ViewTestCase):
     def test_nonexistent_page_is_not_found(self):
         self.assert404(self.client.get('/nonexistent'))
 
+    def test_registration_complains_if_email_is_taken(self):
+        self.register_and_login('foo@example.org', 'test123')
+        self.logout()
+        res = self.client.post('/register', data=dict(
+            email='foo@example.org'
+        ))
+        assert ('foo@example.org is already '
+                'associated with an account') in res.data
+
     def test_registration_works(self):
         self.register_and_login('foo@example.org', 'test123')
         self.logout()


### PR DESCRIPTION
This fixes #41.