### PR TITLE
Redirect user to registration flow and introduce them in the activity stream

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -204,10 +204,9 @@ class User(db.Model, UserMixin, DeploymentMixin): #pylint: disable=no-init,too-f
         flow.
         '''
 
-        join_event = db.session.query(UserJoinedEvent).\
-                     filter_by(user_id=self.id).\
-                     all()
-        return len(join_event) > 0
+        return db.session.query(UserJoinedEvent).\
+               filter_by(user_id=self.id).\
+               first() is not None
 
     def set_fully_registered(self):
         '''

--- a/app/models.py
+++ b/app/models.py
@@ -5,7 +5,7 @@ SQLAlchemy models for the app
 '''
 
 from app import (ORG_TYPES, VALID_SKILL_LEVELS, QUESTIONS_BY_ID, LEVELS,
-                 QUESTIONNAIRES)
+                 QUESTIONNAIRES, MIN_QUESTIONS_TO_JOIN)
 
 from flask import current_app
 from flask_sqlalchemy import SQLAlchemy
@@ -210,6 +210,14 @@ class User(db.Model, UserMixin, DeploymentMixin): #pylint: disable=no-init,too-f
                             SimpleUserEvent.SUBTYPE_USER_JOINED).\
                      all()
         return len(join_event) > 0
+
+    def matches_criteria_for_full_registration(self):
+        '''
+        Returns whether the user matches the criteria to be marked as
+        having fully completed the registration/signup flow.
+        '''
+
+        return len(self.skills) >= MIN_QUESTIONS_TO_JOIN
 
     def set_fully_registered(self):
         '''

--- a/app/models.py
+++ b/app/models.py
@@ -209,14 +209,6 @@ class User(db.Model, UserMixin, DeploymentMixin): #pylint: disable=no-init,too-f
                      all()
         return len(join_event) > 0
 
-    def matches_criteria_for_full_registration(self):
-        '''
-        Returns whether the user matches the criteria to be marked as
-        having fully completed the registration/signup flow.
-        '''
-
-        return len(self.skills) >= MIN_QUESTIONS_TO_JOIN
-
     def set_fully_registered(self):
         '''
         Marks the user as having fully completed the registration/signup

--- a/app/models.py
+++ b/app/models.py
@@ -204,10 +204,8 @@ class User(db.Model, UserMixin, DeploymentMixin): #pylint: disable=no-init,too-f
         flow.
         '''
 
-        join_event = db.session.query(SimpleUserEvent).\
-                     filter(SimpleUserEvent.user_id==self.id).\
-                     filter(SimpleUserEvent.subtype==\
-                            SimpleUserEvent.SUBTYPE_USER_JOINED).\
+        join_event = db.session.query(UserJoinedEvent).\
+                     filter_by(user_id=self.id).\
                      all()
         return len(join_event) > 0
 
@@ -227,11 +225,7 @@ class User(db.Model, UserMixin, DeploymentMixin): #pylint: disable=no-init,too-f
 
         if self.has_fully_registered:
             return
-        join_event = SimpleUserEvent.from_user(
-            self,
-            subtype=SimpleUserEvent.SUBTYPE_USER_JOINED
-        )
-        db.session.add(join_event)
+        db.session.add(UserJoinedEvent.from_user(self))
 
     @property
     def questionnaire_progress(self):
@@ -473,19 +467,13 @@ class UserEvent(Event):
     def from_user(cls, user, **kwargs):
         return cls(user_id=user.id, deployment=user.deployment, **kwargs)
 
-class SimpleUserEvent(UserEvent):
+class UserJoinedEvent(UserEvent):
     '''
-    Any kind of user event that doesn't have any extra data associated
-    with it.
+    A user completed the registration process and joined the network.
     '''
-
-    # A user completed the registration process and joined the network.
-    SUBTYPE_USER_JOINED = 1
-
-    subtype = Column(types.Integer)
 
     __mapper_args__ = {
-        'polymorphic_identity': 'simple_user_event'
+        'polymorphic_identity': 'user_joined_event'
     }
 
 class SharedMessageEvent(UserEvent):

--- a/app/models.py
+++ b/app/models.py
@@ -198,6 +198,34 @@ class User(db.Model, UserMixin, DeploymentMixin): #pylint: disable=no-init,too-f
                 limit(limit)
 
     @property
+    def has_fully_registered(self):
+        '''
+        Returns whether the user has fully completed the registration/signup
+        flow.
+        '''
+
+        join_event = db.session.query(SimpleUserEvent).\
+                     filter(SimpleUserEvent.user_id==self.id).\
+                     filter(SimpleUserEvent.subtype==\
+                            SimpleUserEvent.SUBTYPE_USER_JOINED).\
+                     all()
+        return len(join_event) > 0
+
+    def set_fully_registered(self):
+        '''
+        Marks the user as having fully completed the registration/signup
+        flow, if they haven't already.
+        '''
+
+        if self.has_fully_registered:
+            return
+        join_event = SimpleUserEvent.from_user(
+            self,
+            subtype=SimpleUserEvent.SUBTYPE_USER_JOINED
+        )
+        db.session.add(join_event)
+
+    @property
     def questionnaire_progress(self):
         '''
         Return a dictionary mapping top-level skill area IDs (e.g.,
@@ -436,6 +464,21 @@ class UserEvent(Event):
     @classmethod
     def from_user(cls, user, **kwargs):
         return cls(user_id=user.id, deployment=user.deployment, **kwargs)
+
+class SimpleUserEvent(UserEvent):
+    '''
+    Any kind of user event that doesn't have any extra data associated
+    with it.
+    '''
+
+    # A user completed the registration process and joined the network.
+    SUBTYPE_USER_JOINED = 1
+
+    subtype = Column(types.Integer)
+
+    __mapper_args__ = {
+        'polymorphic_identity': 'simple_user_event'
+    }
 
 class SharedMessageEvent(UserEvent):
     '''

--- a/app/templates/activity.html
+++ b/app/templates/activity.html
@@ -46,6 +46,12 @@
     <p>{{ user_link(event.user) }} shared:</p>
 
     {{ event.message }}
+  {% elif event.type == 'simple_user_event' %}
+    {% if event.subtype == event.SUBTYPE_USER_JOINED %}
+      <p>{{ user_link(event.user) }} joined NOI.</p>
+    {% else %}
+      UNKNOWN SIMPLE USER EVENT SUBTYPE: {{ event.subtype }}
+    {% endif %}
   {% else %}
     UNKNOWN EVENT TYPE: {{ event.type }}
   {% endif %}

--- a/app/templates/activity.html
+++ b/app/templates/activity.html
@@ -46,12 +46,8 @@
     <p>{{ user_link(event.user) }} shared:</p>
 
     {{ event.message }}
-  {% elif event.type == 'simple_user_event' %}
-    {% if event.subtype == event.SUBTYPE_USER_JOINED %}
-      <p>{{ user_link(event.user) }} joined NOI.</p>
-    {% else %}
-      UNKNOWN SIMPLE USER EVENT SUBTYPE: {{ event.subtype }}
-    {% endif %}
+  {% elif event.type == 'user_joined_event' %}
+    <p>{{ user_link(event.user) }} joined NOI.</p>
   {% else %}
     UNKNOWN EVENT TYPE: {{ event.type }}
   {% endif %}

--- a/app/tests/test_models.py
+++ b/app/tests/test_models.py
@@ -158,10 +158,8 @@ class UserRegistrationDbTests(DbTestCase):
     def test_multiple_join_events_are_not_created(self):
         self.user.set_fully_registered()
         self.user.set_fully_registered()
-        join_events = db.session.query(models.SimpleUserEvent).\
-                      filter(models.SimpleUserEvent.user_id==self.user.id).\
-                      filter(models.SimpleUserEvent.subtype==\
-                             models.SimpleUserEvent.SUBTYPE_USER_JOINED).\
+        join_events = db.session.query(models.UserJoinedEvent).\
+                      filter_by(user_id=self.user.id).\
                       all()
         eq_(len(join_events), 1)
 

--- a/app/tests/test_views.py
+++ b/app/tests/test_views.py
@@ -105,9 +105,10 @@ class MultiStepRegistrationTests(ViewTestCase):
     def test_step_3_user_can_join_when_min_questions_are_answered(self):
         self.assertFalse(self.last_created_user.has_fully_registered)
         for i in range(1, MIN_QUESTIONS_TO_JOIN + 1):
-            self.client.post('/register/step/3/opendata/%d' % i, data={
+            res = self.client.post('/register/step/3/opendata/%d' % i, data={
                 'answer': '-1'
             })
+            self.assertEqual(res.status_code, 302)
         self.client.get('/register/step/3')
         self.assertContext('user_can_join', True)
         self.assert200(self.client.get('/activity'))

--- a/app/tests/test_views.py
+++ b/app/tests/test_views.py
@@ -70,7 +70,7 @@ class MultiStepRegistrationTests(ViewTestCase):
 
     def setUp(self):
         super(MultiStepRegistrationTests, self).setUp()
-        self.login()
+        self.login(fully_register=False)
 
     def test_step_2_is_ok(self):
         res = self.client.get('/register/step/2')
@@ -103,12 +103,15 @@ class MultiStepRegistrationTests(ViewTestCase):
         self.assertContext('user_can_join', False)
 
     def test_step_3_user_can_join_when_min_questions_are_answered(self):
+        self.assertFalse(self.last_created_user.has_fully_registered)
         for i in range(1, MIN_QUESTIONS_TO_JOIN + 1):
             self.client.post('/register/step/3/opendata/%d' % i, data={
                 'answer': '-1'
             })
         self.client.get('/register/step/3')
         self.assertContext('user_can_join', True)
+        self.assert200(self.client.get('/activity'))
+        self.assertTrue(self.last_created_user.has_fully_registered)
 
     def test_step_3_answering_last_question_works(self):
         self.assertEqual(len(self.last_created_user.skills), 0)

--- a/app/views.py
+++ b/app/views.py
@@ -34,13 +34,20 @@ def full_registration_required(func):
     are redirected to login; if they are logged in but not fully
     registered, they are redirected to complete the registration
     process.
+
+    Note that if the user is not marked as fully registered but
+    nonetheless meets the criteria for full registration, they will
+    be marked as fully registered and granted access to the view.
     '''
 
     @functools.wraps(func)
     @login_required
     def decorated_view(*args, **kwargs):
         if not current_user.has_fully_registered:
-            return redirect(url_for('views.register_step_2'))
+            if current_user.matches_criteria_for_full_registration():
+                current_user.set_fully_registered()
+            else:
+                return redirect(url_for('views.register_step_2'))
         return func(*args, **kwargs)
 
     return decorated_view

--- a/app/views.py
+++ b/app/views.py
@@ -189,6 +189,7 @@ def register_step_3_area_question(areaid, questionid):
         db.session.commit()
         if len(current_user.skills) >= MIN_QUESTIONS_TO_JOIN:
             current_user.set_fully_registered()
+            db.session.commit()
         if next_questionid:
             return redirect(url_for(
                 'views.register_step_3_area_question',

--- a/app/views.py
+++ b/app/views.py
@@ -11,8 +11,7 @@ from flask_login import login_required, current_user
 
 from app import QUESTIONNAIRES, MIN_QUESTIONS_TO_JOIN
 from app.models import (db, User, UserLanguage, UserExpertiseDomain,
-                        UserSkill, Event, SharedMessageEvent,
-                        SimpleUserEvent)
+                        UserSkill, Event, SharedMessageEvent)
 
 from app.forms import (UserForm, SearchForm, SharedMessageForm,
                        RegisterStep2Form)


### PR DESCRIPTION
This PR is meant to bludgeon two birds with one stone:

1. Adding the following message to the activity stream when a user has fully completed the registration flow:

  ![2015-09-29_16-41-33](https://cloud.githubusercontent.com/assets/124687/10177640/1f22d7ca-66c9-11e5-9226-b22dda265346.png)

2. Directing users to complete the registration process if they haven't already (#49).

Technically, this could be split into two separate PRs, but it shouldn't be too hard to do as one.

Tasks left to do:
- [x] Actually create a `SimpleUserEvent.SUBTYPE_USER_JOINED` event when users complete the registration process.
- [x] Add view logic for displaying `SimpleUserEvent.SUBTYPE_USER_JOINED` in the activity stream.
- [ ] Have the `@full_registration_required` decorator redirect the user to step 3 of registration if they've filled out any of the fields in step 2 *or* have already answered any questionnaire questions. (This can potentially be filed as a separate issue and dealt with later.)
- [x] ~~Generate a database migration.~~ [No migration needed now](https://github.com/GovLab/noi2/pull/55#discussion_r40808534)!
