### PR TITLE
Only search within deployment for most complete profiles

### DIFF
--- a/app/templates/activity.html
+++ b/app/templates/activity.html
@@ -56,12 +56,12 @@
 <h3>Most Complete Profiles</h3>
 
 <ol>
-  {% for ranked_user in most_complete_profiles %}
+  {% for user, score in most_complete_profiles %}
     <li>
-      <p>{{ user_link(ranked_user) }}</p>
+      <p>{{ user_link(user) }}</p>
       <small>
-	{{ ranked_user.skill_count }} /
-	{{ QUESTIONS_BY_ID.keys()|length }} Skills
+        {{ score }} /
+        {{ QUESTIONS_BY_ID.keys()|length }} Skills
       </small>
     </li>
   {% endfor %}

--- a/app/tests/test_models.py
+++ b/app/tests/test_models.py
@@ -90,8 +90,14 @@ class UserSkillDbTests(DbTestCase):
           .one()
 
     def test_get_most_complete_profiles_works(self):
-        users = models.User.get_most_complete_profiles()
-        self.assertEqual(users[-1].email, 'sly@stone-less-knowledgeable.com')
+        user_scores = models.User.get_most_complete_profiles()
+        self.assertEqual(user_scores.all()[-1][0].email, 'sly@stone-less-knowledgeable.com')
+        # should exclude invisible deployments
+        self.assertEqual(user_scores.count(), 5)
+
+        # should respect limit
+        user_scores = models.User.get_most_complete_profiles(limit=3)
+        self.assertEqual(user_scores.count(), 3)
 
     def test_questionnaire_progress_works(self):
         progress = self.sly_less.questionnaire_progress

--- a/fixtures/sample_users.json
+++ b/fixtures/sample_users.json
@@ -1,4 +1,25 @@
 [{
+    "first_name": "outsider",
+    "last_name": "jones",
+    "email": "sly@stone.com",
+    "confirmed_at": "2010-01-01",
+    "deployment": "sword_coast",
+    "skills": {
+        "opendata-open-data-policy-core-mission": 2,
+        "opendata-open-data-policy-sensitive-vs-non-sensitive": 2,
+        "opendata-open-data-policy-crafting-an-open-data-policy": 2,
+        "opendata-open-data-policy-getting-public-input": 2,
+        "opendata-open-data-policy-getting-org-approval": 2,
+        "opendata-implementing-an-open-data-program-scraping-open-data": 2,
+        "opendata-implementing-an-open-data-program-making-machine-readable": 2,
+        "opendata-implementing-an-open-data-program-open-data-formats": -1,
+        "opendata-implementing-an-open-data-program-open-data-license": -1,
+        "opendata-implementing-an-open-data-program-open-data-standards": -1,
+        "opendata-implementing-an-open-data-program-managing-open-data": -1,
+        "opendata-implementing-an-open-data-program-frequency-of-release": -1,
+        "opendata-implementing-an-open-data-program-data-quality-and-integrity": -1
+    }
+},{
     "first_name": "sly",
     "last_name": "stone",
     "email": "sly@stone.com",


### PR DESCRIPTION
* Add an outsider user to our fixtures to broadly test we search within
  deployment
* Simplify `get_most_complete_profiles`, and have it search within deployment
* Update test to prove we're within deployment
* Update template to work with new method signature