### PR TITLE
[WIP] Add support for running liveserver selenium tests

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -16,3 +16,4 @@ COPY . /noi/app
 RUN pip install -r /noi/app/requirements.txt
 
 EXPOSE 5000
+EXPOSE 5001

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -32,3 +32,4 @@ simple-crypt==4.1.7
 python-slugify==1.1.3
 wtforms_alchemy
 redis
+selenium

--- a/app/tests/test_liveserver.py
+++ b/app/tests/test_liveserver.py
@@ -1,0 +1,31 @@
+from app.factory import create_app
+
+from flask.ext.testing import LiveServerTestCase
+
+from .test_views import ViewTestCase
+
+from functools import partial
+from selenium import webdriver
+import unittest
+
+class LiveServerTests(LiveServerTestCase):
+    BASE_APP_CONFIG = ViewTestCase.BASE_APP_CONFIG.copy()
+    BASE_APP_CONFIG.update(
+        WTF_CSRF_ENABLED=True,
+        LIVESERVER_PORT=5001
+    )
+
+    def create_app(self):
+        app = create_app(config=self.BASE_APP_CONFIG)
+        app.run = partial(app.run, host='0.0.0.0')
+        return app
+
+    @unittest.skip("need to set up an ambassador container")
+    def test_foo(self):
+        browser = webdriver.Remote(
+            command_executor='http://phantomjs:8910/wd/hub',
+            desired_capabilities={
+              'browserName': 'phantomjs'
+            }
+        )
+        browser.get('http://app:5001')

--- a/app/tests/test_views.py
+++ b/app/tests/test_views.py
@@ -10,16 +10,17 @@ from .test_models import DbTestCase
 LOGGED_IN_SENTINEL = '<a href="/me"'
 
 class ViewTestCase(DbTestCase):
-    def create_app(self):
-        config = self.BASE_APP_CONFIG.copy()
-        config.update(
+    BASE_APP_CONFIG = DbTestCase.BASE_APP_CONFIG.copy()
+    BASE_APP_CONFIG.update(
             DEBUG=False,
             WTF_CSRF_ENABLED=False,
             # This speeds tests up considerably.
             SECURITY_PASSWORD_HASH='plaintext',
             CACHE_NO_NULL_WARNING=True,
-        )
-        return create_app(config=config)
+    )
+
+    def create_app(self):
+        return create_app(config=self.BASE_APP_CONFIG)
 
     def register_and_login(self, username, password):
         res = self.client.post('/register', data=dict(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ app:
         - ./migrations:/migrations
     environment:
         - NOI_ENVIRONMENT # unless production, assumed "development"
+    ports:
+        - "5001:5001"
 db:
     image: postgres:9.4
 web:
@@ -22,6 +24,14 @@ web:
     ports:
         - "80:80"
         - "443:443"
+phantomjs:
+    image: cmfatih/phantomjs
+    links:
+        - web
+    expose:
+        - 8910
+    entrypoint: phantomjs
+    command: --webdriver=8910
 #worker:
 #    build: app/
 #    command: /noi/run.sh

--- a/nosetests.sh
+++ b/nosetests.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -e
 
-docker-compose run app nosetests -w /noi $@
+docker-compose run --service-ports app nosetests -w /noi $@


### PR DESCRIPTION
I'm trying to use phantomJS in a separate docker container as suggested in https://github.com/GovLab/noi2/issues/37#issuecomment-143237592, but there's a few wrinkles so far--most notably the fact that, since the `app` container and the `phantomjs` container need access to each other, we might have to link them together through an [ambassador container](https://docs.docker.com/articles/ambassador_pattern_linking/).
