### PR TITLE
Add rudimentary SASS integration.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .env
 *.pyc
 app/config/local_config.yml
+app/static/css
 *.mo
 .keys
 backups

--- a/app/factory.py
+++ b/app/factory.py
@@ -10,7 +10,7 @@ from flask_security import SQLAlchemyUserDatastore, user_registered
 from flask_security.utils import get_identity_attributes
 
 from app import (csrf, cache, mail, bcrypt, s3, assets, security,
-                 babel, celery, alchemydumps,
+                 babel, celery, alchemydumps, sass,
                  QUESTIONNAIRES, NOI_COLORS, LEVELS, ORG_TYPES, QUESTIONS_BY_ID)
 from app.config.schedule import CELERYBEAT_SCHEDULE
 from app.forms import (NOIConfirmRegisterForm, NOIForgotPasswordForm,
@@ -288,8 +288,9 @@ def create_app(config=None): #pylint: disable=too-many-statements
         db.session.add(user)
         db.session.commit()
 
-    return app
+    sass.init_app(app)
 
+    return app
 
 def create_celery(app=None):
     '''

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -32,3 +32,4 @@ simple-crypt==4.1.7
 python-slugify==1.1.3
 wtforms_alchemy
 redis
+libsass==0.8.3

--- a/app/sass.py
+++ b/app/sass.py
@@ -1,0 +1,28 @@
+from sassutils.wsgi import SassMiddleware
+import sassutils.builder
+
+SASS_DIR = 'static/sass'
+CSS_DIR = 'static/css'
+
+def init_app(app):
+    if app.config['DEBUG']:
+        # If we're debugging, we want to build SASS for each
+        # request so that we have a nice development flow:
+        #
+        # http://hongminhee.org/libsass-python/frameworks/flask.html
+        #
+        # However, because nginx intercepts everything at /static/, we can't
+        # have the SASS middleware use that path, so instead we'll
+        # put all compiled SASS in a different path that we have
+        # control over.
+        app.jinja_env.globals['COMPILED_SASS_ROOT'] = '/sass-middleware'
+        app.wsgi_app = SassMiddleware(app.wsgi_app, {
+            'app': (SASS_DIR, CSS_DIR,
+                    app.jinja_env.globals['COMPILED_SASS_ROOT'])
+        })
+    else:
+        app.jinja_env.globals['COMPILED_SASS_ROOT'] = '/' + CSS_DIR
+
+def build_files():
+    sassutils.builder.build_directory('/noi/app/' + SASS_DIR,
+                                      '/noi/app/' + CSS_DIR)

--- a/app/static/sass/styles.scss
+++ b/app/static/sass/styles.scss
@@ -1,0 +1,7 @@
+// This is just a sample SASS file.
+
+body {
+  html {
+    color: blue;
+  }
+}

--- a/app/templates/sass-test.html
+++ b/app/templates/sass-test.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="stylesheet" href="{{ COMPILED_SASS_ROOT }}/styles.scss.css">
+<title>SASS Test</title>
+<p>This is a SASS test.</p>
+<p>
+  <code>COMPILED_SASS_ROOT</code> is <code>{{ COMPILED_SASS_ROOT }}</code>.
+</p>
+<p>
+  See compiled SASS at
+  <a href="{{ COMPILED_SASS_ROOT }}/styles.scss.css">{{ COMPILED_SASS_ROOT }}/styles.scss.cs</a>.
+<p>

--- a/app/tests/test_sass.py
+++ b/app/tests/test_sass.py
@@ -1,0 +1,8 @@
+from app import sass
+
+def test_sass_compiles():
+    '''
+    Just build all our SASS files and make sure no errors are thrown.
+    '''
+
+    sass.build_files()

--- a/app/views.py
+++ b/app/views.py
@@ -380,3 +380,13 @@ def feedback():
     Feedback page.
     '''
     return render_template('feedback.html', **{})
+
+@views.route('/sass-test')
+def sass_test():
+    '''
+    This is just a temporary endpoint that we can test SASS
+    integration at. Once we actually use SASS for the whole site,
+    this route can be removed.
+    '''
+
+    return render_template('sass-test.html')

--- a/manage.py
+++ b/manage.py
@@ -4,7 +4,7 @@ NoI manage.py
 Scripts to run the server and perform maintenance operations
 '''
 
-from app import mail, models, LEVELS, ORG_TYPES
+from app import mail, models, sass, LEVELS, ORG_TYPES
 from app.factory import create_app
 from app.models import db, User
 from app.utils import csv_reader
@@ -203,6 +203,16 @@ def populate_db():
     load_fixture(password=encrypt_password('foobar'))
     return 0
 
+@manager.command
+def build_sass():
+    """
+    Build SASS files.
+    """
+
+    print "Building SASS files..."
+    sass.build_files()
+    print "Done. Built SASS files are in app/%s." % sass.CSS_DIR
+    return 0
 
 if __name__ == '__main__':
     subprocess.call('../symlink-hooks.sh', shell=True)

--- a/run.sh
+++ b/run.sh
@@ -18,6 +18,7 @@ if [ "$NOI_ENVIRONMENT" == production ]; then
     cd /noi
     python manage.py db upgrade
     python manage.py translate_compile
+    python manage.py build_sass
     gunicorn wsgi:application -b 0.0.0.0:5000
 elif [ "$NOI_ENVIRONMENT" == celery ]; then
     #cd /noi && celery worker -Q celery -A celery_core.celery --loglevel=debug


### PR DESCRIPTION
Since @claudioccm's [CSS](https://github.com/claudioccm/noi-ui) is SASS-based, it'd be really nice if we could have the source SASS in this repository and easily iterate on it from here.

This PR adds [libsass-python](https://github.com/dahlia/libsass-python) to our `app` container and integrates SASS into our build process. 

**For development**, we use SASS middleware that regenerates the SASS on each request and gives us handy error feedback in our views like this:

> ![2015-10-02_12-56-32](https://cloud.githubusercontent.com/assets/124687/10252375/158b52f8-6905-11e5-90ac-f3d84fa9068a.png)

**For production**, I've added `manage.py build_sass`, which is executed as part of `run.sh`, so that our compiled SASS is served as static CSS in production.

We also compile our SASS as part of our test suite to make sure it's always syntactically correct.