### PR TITLE
use a $path-to-static sass variable

### DIFF
--- a/app/static/sass/_nav.scss
+++ b/app/static/sass/_nav.scss
@@ -14,7 +14,7 @@
             color: transparent;
             flex: 1;
             letter-spacing: 1px;
-            background-image: url("../static/img/noi-logo-ok.png");
+            background-image: url(#{$path-to-static}/img/noi-logo-ok.png);
             background-size: contain;
             background-repeat: no-repeat;
             height: 24px;

--- a/app/static/sass/_off-canvas.scss
+++ b/app/static/sass/_off-canvas.scss
@@ -50,7 +50,7 @@
     }
 
     .e-govlab-logo {
-        background-image: url("../img/govlab-logo-white.png");
+        background-image: url(#{$path-to-static}/img/govlab-logo-white.png);
         background-repeat: no-repeat;
         background-position: center bottom;
         background-size: contain;

--- a/app/static/sass/styles.scss
+++ b/app/static/sass/styles.scss
@@ -1,3 +1,5 @@
+$path-to-static: "/static";
+
 $gray-05: rgba(0,0,0,0.05);
 $gray-10: rgba(0,0,0,0.1);
 $gray-20: rgba(0,0,0,0.2);


### PR DESCRIPTION
Because the development and production paths to SASS files are located at [different paths](https://github.com/GovLab/noi2/blob/master/app/sass.py), this unfortunately makes referencing the static assets via relative paths problematic.

To get around this, we'll define a SASS variable called `$path-to-static` and use [interpolation syntax](https://web-design-weekly.com/snippets/url-as-a-sass-variable/) to reference our images and other static assets from our CSS.