### PR TITLE
[WIP] Add base navigation and user menu for fancy new UI

### DIFF
--- a/app/templates/__base_new__.html
+++ b/app/templates/__base_new__.html
@@ -34,7 +34,7 @@
     <p>{{ message|safe }}</p>
   </div>
 {% endfor %}
-
+    {% block header %}{% endblock %}
     {% block content %}{% endblock %}
 
     <script src="{{ url_for('static', filename='vendor/jquery-1.11.3.min.js') }}"></script>

--- a/app/templates/__base_ui__.html
+++ b/app/templates/__base_ui__.html
@@ -1,0 +1,35 @@
+{% extends "__base_new__.html" %}
+
+{% block header %}
+<header class="b-navigation">
+    <section class="e-top-bar">
+        <h1 class="e-logo">{{ gettext('Network of Innovators') }}</h1>
+        <div class="e-user-utils">
+            <span class="e-post material-icons">chat</span>
+            <img class="e-user-picture" src="{{ current_user.picture_url }}">
+        </div>
+    </section>
+    <nav class="e-main-nav">
+            <a href="{{ url_for('views.activity') }}" class="e-nav-item">
+                <span class="material-icons">home</span>
+                {{ gettext('Home') }}
+            </a>
+            <a href="{{ url_for('views.match') }}" class="e-nav-item">
+                <span class="material-icons">group</span>
+                {{ gettext('Match Me') }}
+            </a>
+            <a href="{{ url_for('views.search') }}" class="e-nav-item">
+                <span class="material-icons">search</span>
+                {{ gettext('Find Innovator') }}
+            </a>
+            <a href="{{ url_for('views.network') }}" class="e-nav-item">
+                <span class="material-icons">language</span>
+                {{ gettext('View Network') }}
+            </a>
+            <a href="{{ url_for('views.feedback') }}" class="e-nav-item">
+                <span class="material-icons">feedback</span>
+                {{ gettext('Share Feedback') }}
+            </a>
+    </nav>
+</header>
+{% endblock %}

--- a/app/templates/network.html
+++ b/app/templates/network.html
@@ -1,0 +1,5 @@
+{% extends "__base_ui__.html" %}
+
+{% block content %}
+  <p>Sorry, this feature of the site is not yet available.</p>
+{% endblock %}

--- a/app/tests/test_views.py
+++ b/app/tests/test_views.py
@@ -302,6 +302,11 @@ class ViewTests(ViewTestCase):
         self.assert200(res)
         assert "Search for Innovators" in res.data
 
+    def test_network_is_ok(self):
+        self.login()
+        res = self.client.get('/network')
+        self.assert200(res)
+
     def test_search_results_is_ok(self):
         self.login()
         res = self.client.get('/search?country=ZZ')

--- a/app/views.py
+++ b/app/views.py
@@ -405,6 +405,15 @@ def activity():
         'most_connected_profiles': User.get_most_connected_profiles(limit=5)
     })
 
+@views.route('/network')
+@full_registration_required
+def network():
+    '''
+    View the network.
+    '''
+
+    return render_template('network.html')
+
 @views.route('/feedback')
 def feedback():
     '''


### PR DESCRIPTION
This adds the base navigation (`base_ui` in the style guide) and user profile menu for the fancy new UI, with a trivial `/network` view to showcase it.