### PR TITLE
Use bootstrap's alert.js for fancy new UI alerts

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -42,6 +42,7 @@ main_css = Bundle('css/vendor/bootstrap.css',
 assets.register('main_css', main_css)
 
 main_js = Bundle('js/main.js',
+                 'vendor/bootstrap/js/alert.js',
                  #filters='jsmin',
                  output='gen/main_packed.%(version)s.js')
 assets.register('main_js', main_js)

--- a/app/static/vendor/bootstrap/js/alert.js
+++ b/app/static/vendor/bootstrap/js/alert.js
@@ -1,0 +1,94 @@
+/* ========================================================================
+ * Bootstrap: alert.js v3.3.5
+ * http://getbootstrap.com/javascript/#alerts
+ * ========================================================================
+ * Copyright 2011-2015 Twitter, Inc.
+ * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
+ * ======================================================================== */
+
+
++function ($) {
+  'use strict';
+
+  // ALERT CLASS DEFINITION
+  // ======================
+
+  var dismiss = '[data-dismiss="alert"]'
+  var Alert   = function (el) {
+    $(el).on('click', dismiss, this.close)
+  }
+
+  Alert.VERSION = '3.3.5'
+
+  Alert.TRANSITION_DURATION = 150
+
+  Alert.prototype.close = function (e) {
+    var $this    = $(this)
+    var selector = $this.attr('data-target')
+
+    if (!selector) {
+      selector = $this.attr('href')
+      selector = selector && selector.replace(/.*(?=#[^\s]*$)/, '') // strip for ie7
+    }
+
+    var $parent = $(selector)
+
+    if (e) e.preventDefault()
+
+    if (!$parent.length) {
+      $parent = $this.closest('.alert')
+    }
+
+    $parent.trigger(e = $.Event('close.bs.alert'))
+
+    if (e.isDefaultPrevented()) return
+
+    $parent.removeClass('in')
+
+    function removeElement() {
+      // detach from parent, fire event then clean up data
+      $parent.detach().trigger('closed.bs.alert').remove()
+    }
+
+    $.support.transition && $parent.hasClass('fade') ?
+      $parent
+        .one('bsTransitionEnd', removeElement)
+        .emulateTransitionEnd(Alert.TRANSITION_DURATION) :
+      removeElement()
+  }
+
+
+  // ALERT PLUGIN DEFINITION
+  // =======================
+
+  function Plugin(option) {
+    return this.each(function () {
+      var $this = $(this)
+      var data  = $this.data('bs.alert')
+
+      if (!data) $this.data('bs.alert', (data = new Alert(this)))
+      if (typeof option == 'string') data[option].call($this)
+    })
+  }
+
+  var old = $.fn.alert
+
+  $.fn.alert             = Plugin
+  $.fn.alert.Constructor = Alert
+
+
+  // ALERT NO CONFLICT
+  // =================
+
+  $.fn.alert.noConflict = function () {
+    $.fn.alert = old
+    return this
+  }
+
+
+  // ALERT DATA-API
+  // ==============
+
+  $(document).on('click.bs.alert.data-api', dismiss, Alert.prototype.close)
+
+}(jQuery);

--- a/app/templates/__base_new__.html
+++ b/app/templates/__base_new__.html
@@ -21,23 +21,18 @@
    stay near the top of the HTML so that screen readers announce them
    first. #}
 
+{% from "_macros.html" import render_alert %}
 {% for category, message in get_flashed_messages(with_categories=true) %}
-  {% if category == 'error' %}
-    {% set flashed_message_class = 'm-error' %}
-  {% else %}
-    {% set flashed_message_class = 'm-success' %}
-  {% endif %}
-  <div class="b-alert-message {{flashed_message_class}}">
-    <!-- TODO: This <div> needs to be a <button> for a11y. -->
-    <!-- TODO: Move the JS out of an onclick attribute. -->
-    <div class="material-icons" onclick="$(this).parent().addClass('m-hide')">close</div>
-    <p>{{ message|safe }}</p>
-  </div>
+  {{ render_alert(message=message, category=category) }}
 {% endfor %}
 
+    {% block header %}{% endblock %}
     {% block content %}{% endblock %}
 
     <script src="{{ url_for('static', filename='vendor/jquery-1.11.3.min.js') }}"></script>
+    {% assets "main_js" %}
+      <script type="text/javascript" src="{{ ASSET_URL }}"></script>
+    {% endassets %}
     {% block page_script %}{% endblock %}
 </body>
 </html>

--- a/app/templates/_macros.html
+++ b/app/templates/_macros.html
@@ -1,0 +1,12 @@
+{% macro render_alert(message, category) %}
+  {% if category == 'error' %}
+    {% set flashed_message_class = 'm-error' %}
+  {% else %}
+    {% set flashed_message_class = 'm-success' %}
+  {% endif %}
+  <div class="b-alert-message alert {{flashed_message_class}}">
+    <!-- TODO: This <div> needs to be a <button> for a11y. -->
+    <div class="material-icons" data-dismiss="alert">close</div>
+    <p>{{ message|safe }}</p>
+  </div>
+{% endmacro %}

--- a/app/templates/style-guide/alert.html
+++ b/app/templates/style-guide/alert.html
@@ -1,0 +1,21 @@
+{% extends "__base_new__.html" %}
+
+{% block content %}
+  <div class="b-onboarding">
+  <p>
+    We use Bootstrap's <a target="_blank" href="http://getbootstrap.com/javascript/#alerts">alert plugin</a> for alerts.
+  </p>
+  <p>
+    This page contains multiple alerts.
+  </p>
+  <p>
+    Alerts are stacked atop one another, so the user must dismiss
+    one to see the alert underneath it.
+  </p>
+  </div>
+
+  {% from "_macros.html" import render_alert %}
+
+  {{ render_alert("This is a normal alert") }}
+  {{ render_alert("This is an error alert", "error") }}
+{% endblock %}


### PR DESCRIPTION
This does a few things:

* Replaces a janky `onclick` handler in our current alert code with [Bootstrap's alert plugin](http://getbootstrap.com/javascript/#alerts) (via its data API).
* Moves the alert-rendering code into a separate `_macros.html` file, so it's modularized and can be manually tested.
* Adds basic documentation and a manual test for the alert styling and dismissal logic under `/style-guide/alert`.

In general, I'd like to leverage jQuery plug-ins like this for our JS needs rather than writing our own from scratch, since they're well-tested in the wild and also deal with lots of edge cases (e.g. older browsers, accessibility issues) that we don't want to have to deal with the hard way.