### PR TITLE
Make new UI's contextual nav work w/ Bootstrap's tab plugin

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -44,6 +44,7 @@ assets.register('main_css', main_css)
 main_js = Bundle('js/main.js',
                  'vendor/bootstrap/js/alert.js',
                  'vendor/bootstrap/js/modal.js',
+                 'vendor/bootstrap/js/tab.js',
                  #filters='jsmin',
                  output='gen/main_packed.%(version)s.js')
 assets.register('main_js', main_js)

--- a/app/static/sass/_activity.scss
+++ b/app/static/sass/_activity.scss
@@ -22,12 +22,20 @@
         display: inline-block;
         margin: 0 40px;
 
-        &.m-active {
+        // Note that &.active is applied by Bootstrap's tab plugin.
+        &.m-active, &.active {
             transform: scale(1.3);
             color: $white-80;
             font-weight: 600;
         }   
     }
+}
+
+// The content of contextual nav "tabs" should be contained in
+// elements with role="tabpanel"; only one of them should have .active,
+// which is managed by Bootstrap's tab plugin.
+[role="tabpanel"]:not(.active) {
+    display: none;
 }
 
 .b-activity-feed {

--- a/app/static/vendor/bootstrap/js/tab.js
+++ b/app/static/vendor/bootstrap/js/tab.js
@@ -1,0 +1,155 @@
+/* ========================================================================
+ * Bootstrap: tab.js v3.3.5
+ * http://getbootstrap.com/javascript/#tabs
+ * ========================================================================
+ * Copyright 2011-2015 Twitter, Inc.
+ * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
+ * ======================================================================== */
+
+
++function ($) {
+  'use strict';
+
+  // TAB CLASS DEFINITION
+  // ====================
+
+  var Tab = function (element) {
+    // jscs:disable requireDollarBeforejQueryAssignment
+    this.element = $(element)
+    // jscs:enable requireDollarBeforejQueryAssignment
+  }
+
+  Tab.VERSION = '3.3.5'
+
+  Tab.TRANSITION_DURATION = 150
+
+  Tab.prototype.show = function () {
+    var $this    = this.element
+    var $ul      = $this.closest('ul:not(.dropdown-menu)')
+    var selector = $this.data('target')
+
+    if (!selector) {
+      selector = $this.attr('href')
+      selector = selector && selector.replace(/.*(?=#[^\s]*$)/, '') // strip for ie7
+    }
+
+    if ($this.parent('li').hasClass('active')) return
+
+    var $previous = $ul.find('.active:last a')
+    var hideEvent = $.Event('hide.bs.tab', {
+      relatedTarget: $this[0]
+    })
+    var showEvent = $.Event('show.bs.tab', {
+      relatedTarget: $previous[0]
+    })
+
+    $previous.trigger(hideEvent)
+    $this.trigger(showEvent)
+
+    if (showEvent.isDefaultPrevented() || hideEvent.isDefaultPrevented()) return
+
+    var $target = $(selector)
+
+    this.activate($this.closest('li'), $ul)
+    this.activate($target, $target.parent(), function () {
+      $previous.trigger({
+        type: 'hidden.bs.tab',
+        relatedTarget: $this[0]
+      })
+      $this.trigger({
+        type: 'shown.bs.tab',
+        relatedTarget: $previous[0]
+      })
+    })
+  }
+
+  Tab.prototype.activate = function (element, container, callback) {
+    var $active    = container.find('> .active')
+    var transition = callback
+      && $.support.transition
+      && ($active.length && $active.hasClass('fade') || !!container.find('> .fade').length)
+
+    function next() {
+      $active
+        .removeClass('active')
+        .find('> .dropdown-menu > .active')
+          .removeClass('active')
+        .end()
+        .find('[data-toggle="tab"]')
+          .attr('aria-expanded', false)
+
+      element
+        .addClass('active')
+        .find('[data-toggle="tab"]')
+          .attr('aria-expanded', true)
+
+      if (transition) {
+        element[0].offsetWidth // reflow for transition
+        element.addClass('in')
+      } else {
+        element.removeClass('fade')
+      }
+
+      if (element.parent('.dropdown-menu').length) {
+        element
+          .closest('li.dropdown')
+            .addClass('active')
+          .end()
+          .find('[data-toggle="tab"]')
+            .attr('aria-expanded', true)
+      }
+
+      callback && callback()
+    }
+
+    $active.length && transition ?
+      $active
+        .one('bsTransitionEnd', next)
+        .emulateTransitionEnd(Tab.TRANSITION_DURATION) :
+      next()
+
+    $active.removeClass('in')
+  }
+
+
+  // TAB PLUGIN DEFINITION
+  // =====================
+
+  function Plugin(option) {
+    return this.each(function () {
+      var $this = $(this)
+      var data  = $this.data('bs.tab')
+
+      if (!data) $this.data('bs.tab', (data = new Tab(this)))
+      if (typeof option == 'string') data[option]()
+    })
+  }
+
+  var old = $.fn.tab
+
+  $.fn.tab             = Plugin
+  $.fn.tab.Constructor = Tab
+
+
+  // TAB NO CONFLICT
+  // ===============
+
+  $.fn.tab.noConflict = function () {
+    $.fn.tab = old
+    return this
+  }
+
+
+  // TAB DATA-API
+  // ============
+
+  var clickHandler = function (e) {
+    e.preventDefault()
+    Plugin.call($(this), 'show')
+  }
+
+  $(document)
+    .on('click.bs.tab.data-api', '[data-toggle="tab"]', clickHandler)
+    .on('click.bs.tab.data-api', '[data-toggle="pill"]', clickHandler)
+
+}(jQuery);

--- a/app/templates/style-guide/tab.html
+++ b/app/templates/style-guide/tab.html
@@ -1,0 +1,23 @@
+{% extends "style-guide/base_ui.html" %}
+
+{% block title %}Tabs Example{% endblock %}
+
+
+{% block content %}
+<nav class="b-contextual-nav">
+    <ul class="e-menu-items" role="tablist">
+        <li role="presentation" class="e-item active"><a href="#tab1" aria-controls="tab1" role="tab" data-toggle="tab">Tab 1</a></li>
+        <li role="presentation" class="e-item"><a href="#tab2" aria-controls="tab2" role="tab" data-toggle="tab">Tab 2</a></li>
+    </ul>
+</nav>
+
+<div>
+  <div role="tabpanel" id="tab1" class="active">
+    <p>We use Bootstrap's <a target="_blank" href="http://getbootstrap.com/javascript/#tabs">tab plugin</a> for tabs.</p>
+  </div>
+  <div role="tabpanel" id="tab2">
+    <p>I am tab 2.</p>
+  </div>
+</div>
+
+{% endblock %}


### PR DESCRIPTION
Similar to #102 and #101, here we add Bootstrap's [tab plugin](http://getbootstrap.com/javascript/#tabs) and make a few minor modifications to `.b-contextual-nav` so the two are compatible with each other. A new `tab` style guide page can be used to manually test the integration.