### PR TITLE
Improve registration step 3 styling

### DIFF
--- a/app/templates/register-step-3.html
+++ b/app/templates/register-step-3.html
@@ -7,6 +7,15 @@
   {% endif %}
 {% endblock %}
 
+{% block page_style_pre %}
+  {# This is a placeholder until we fix #115. #}
+  <style>
+    html, body {
+      background: rgba(0, 0, 0, 0.6);
+    }
+  </style>
+{% endblock %}
+
 {% block content %}
 
 {% if not question %}
@@ -55,7 +64,7 @@
 		<div>
 		    <br>
 		    {% if user_can_join %}
-		        <a href="{{ url_for('views.activity') }}">{{ gettext('Join') }}</a>
+		        <p><a class="b-button" href="{{ url_for('views.activity') }}">{{ gettext('Join') }}</a></p>
 		    {% else %}
 			{{ gettext("You must answer at least %d more question(s) to join." % questions_left) }}
 		    {% endif %}


### PR DESCRIPTION
This helps with #115 and #116:

![2015-10-08_11-47-16](https://cloud.githubusercontent.com/assets/124687/10371675/74b8b7fa-6db2-11e5-88cf-05f3e25a5350.png)

I'm still not a big fan of the way that "join" button looks, as it seems sorta "disabled", but it is indeed better than being completely unstyled!
