### PR TITLE
In forms, use flask.ext.babel.get_locale() instead of BABEL_DEFAULT_LOCALE

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -6,6 +6,7 @@ from app import LOCALES
 from app.models import User
 
 from flask import current_app
+from flask.ext.babel import get_locale
 from flask_wtf import Form
 from flask_wtf.file import FileField, FileAllowed
 from flask_security.forms import (LoginForm, RegisterForm,
@@ -116,8 +117,8 @@ class UserForm(ModelForm):  #pylint: disable=no-init,too-few-public-methods
     locales = CallableChoicesSelectMultipleField(
         label=lazy_gettext('Languages'),
         widget=ChosenSelect(multiple=True),
-        choices=lambda: [(l.language, l.get_language_name(current_app.config.get(
-            'BABEL_DEFAULT_LOCALE'))) for l in LOCALES])
+        choices=lambda: [(l.language, l.get_language_name(get_locale()))
+                         for l in LOCALES])
     expertise_domain_names = CallableChoicesSelectMultipleField(
         label=lazy_gettext('Domains of Expertise'),
         widget=ChosenSelect(multiple=True),
@@ -140,8 +141,8 @@ class SearchForm(Form):
     locales = CallableChoicesSelectMultipleField(
         label=lazy_gettext('Languages'),
         widget=ChosenSelect(multiple=True),
-        choices=lambda: [(l.language, l.get_language_name(current_app.config.get(
-            'BABEL_DEFAULT_LOCALE'))) for l in LOCALES])
+        choices=lambda: [(l.language, l.get_language_name(get_locale()))
+                         for l in LOCALES])
     expertise_domain_names = CallableChoicesSelectMultipleField(
         label=lazy_gettext('Domains of Expertise'),
         widget=ChosenSelect(multiple=True),


### PR DESCRIPTION
I think that [`flask.ext.babel.get_locale()`](https://pythonhosted.org/Flask-Babel/#flask.ext.babel.get_locale) is more appropriate in most cases, because it will ultimately take into account the current user's current locale. Which I think falls back to `BABEL_DEFAULT_LOCALE` if no other information is available (especially if we don't set our own [`localeselector`](https://pythonhosted.org/Flask-Babel/#flask.ext.babel.Babel.localeselector), which I think is currently the case).

For instance, even if `BABEL_DEFAULT_LOCALE` is `es`, if the current user decides to set their locale to `en`, they're going to want to see country/language names in English rather than the deployment's default of Spanish, right?

The only potential wrinkle here is if the form is instantiated outside of the context of a request: in this case, `get_locale()` will return `None` and could make weird things happen... But forms are pretty much only used within the context of requests, right?