### PR TITLE
Add render_tab_bar, render_tab_panel macros.

### DIFF
--- a/app/templates/_macros.html
+++ b/app/templates/_macros.html
@@ -17,3 +17,19 @@
     <p>{{ message|safe }}</p>
   </div>
 {% endmacro %}
+
+{% macro render_tab_bar(tabs, active_tab) %}
+<nav class="b-contextual-nav">
+    <ul class="e-menu-items" role="tablist">
+        {% for tabid, tablabel in tabs %}
+        <li role="presentation" class="e-item {% if tabid == active_tab %}active{% endif %}"><a href="#{{ tabid }}" aria-controls="{{ tabid }}" role="tab" data-toggle="tab">{{ tablabel }}</a></li>
+        {% endfor %}
+    </ul>
+</nav>
+{% endmacro %}
+
+{% macro render_tab_panel(tabid, active_tab, class='') %}
+<section role="tabpanel" id="{{ tabid }}" class="{{ class }} {% if tabid == active_tab %}active{% endif %}">
+  {{ caller() }}
+</section>
+{% endmacro %}

--- a/app/templates/activity.html
+++ b/app/templates/activity.html
@@ -1,23 +1,22 @@
 {% extends "__base_ui__.html" %}
 
-{% from "_macros.html" import get_user_avatar_url %}
+{% from "_macros.html" import get_user_avatar_url, render_tab_bar, render_tab_panel %}
+
+{% set tabs = [
+  ('activity', gettext('Activity')),
+  ('connected', gettext('Most Connected')),
+  ('complete', gettext('Most Complete')),
+  ('progress', gettext('My Profile Progress'))
+] %}
+
+{% set active_tab = active_tab|default(tabs[0][0]) %}
 
 {% block content %}
 
-<nav class="b-contextual-nav">
-    <ul class="e-menu-items" role="tablist">
-        <li role="presentation" class="e-item active"><a href="#activity" aria-controls="activity" role="tab" data-toggle="tab">{{ gettext('Activity') }}</a></li>
-        <li role="presentation" class="e-item"><a href="#connected" aria-controls="connected" role="tab" data-toggle="tab">{{ gettext('Most Connected') }}</a></li>
-        <li role="presentation" class="e-item"><a href="#complete" aria-controls="complete" role="tab" data-toggle="tab">{{ gettext('Most Complete Profiles') }}</a></li>
-        <li role="presentation" class="e-item"><a href="#progress" aria-controls="progress" role="tab" data-toggle="tab">{{ gettext('My Profile Progress') }}</a></li>
-    </ul>
-</nav>
+{{ render_tab_bar(tabs, active_tab) }}
 
 <div> <!-- Start of tab panel container -->
 
-<section role="tabpanel" id="activity" class="b-activity-feed active">
-
-  <ul class="e-activity-feed-container">
 {% macro user_link(user) -%}
 <strong><a href="{{ url_for('views.get_user', userid=user.id) }}">{{ user.full_name }}</a></strong>
 {%- endmacro %}
@@ -26,6 +25,8 @@
 <img class="e-user-picture" src="{{ get_user_avatar_url(user) }}" alt="">
 {%- endmacro %}
 
+{% call render_tab_panel('activity', active_tab, class='b-activity-feed') %}
+  <ul class="e-activity-feed-container">
 {% for event in events %}
   <li class="e-feed-item">
   <time datetime="{{ event.created_at }}"></time>
@@ -53,9 +54,9 @@
   </li>
 {% endfor %}
   </ul>
-</section>
+{% endcall %}
 
-<div role="tabpanel" id="connected">
+{% call render_tab_panel('connected', active_tab) %}
 <ol>
   {% for user, score in most_connected_profiles %}
     <li>
@@ -66,9 +67,9 @@
     </li>
   {% endfor %}
 </ol>
-</div>
+{% endcall %}
 
-<div role="tabpanel" id="complete">
+{% call render_tab_panel('complete', active_tab) %}
 <ol>
   {% for user, score in most_complete_profiles %}
     <li>
@@ -80,10 +81,9 @@
     </li>
   {% endfor %}
 </ol>
-</div>
+{% endcall %}
 
-<section role="tabpanel" id="progress" class="b-profile-progress">
-
+{% call render_tab_panel('progress', active_tab, class='b-profile-progress') %}
 <ul class="e-progress-container">
   {% set q_progress = user.questionnaire_progress %}
   {% for questionnaire in QUESTIONNAIRES %}
@@ -121,7 +121,7 @@
   </p>
 </footer>
 
-</section>
+{% endcall %}
 
 </div> <!-- End of tab panel container -->
 

--- a/app/templates/style-guide/tab.html
+++ b/app/templates/style-guide/tab.html
@@ -2,22 +2,26 @@
 
 {% block title %}Tabs Example{% endblock %}
 
+{% from "_macros.html" import render_tab_bar, render_tab_panel %}
+
+{% set tabs = [
+  ('tab1', 'Tab 1'),
+  ('tab2', 'Tab 2'),
+] %}
+
+{% set active_tab = active_tab|default(tabs[0][0]) %}
 
 {% block content %}
-<nav class="b-contextual-nav">
-    <ul class="e-menu-items" role="tablist">
-        <li role="presentation" class="e-item active"><a href="#tab1" aria-controls="tab1" role="tab" data-toggle="tab">Tab 1</a></li>
-        <li role="presentation" class="e-item"><a href="#tab2" aria-controls="tab2" role="tab" data-toggle="tab">Tab 2</a></li>
-    </ul>
-</nav>
+{{ render_tab_bar(tabs, active_tab) }}
 
 <div>
-  <div role="tabpanel" id="tab1" class="active">
+  {% call render_tab_panel('tab1', active_tab) %}
     <p>We use Bootstrap's <a target="_blank" href="http://getbootstrap.com/javascript/#tabs">tab plugin</a> for tabs.</p>
-  </div>
-  <div role="tabpanel" id="tab2">
+  {% endcall %}
+
+  {% call render_tab_panel('tab2', active_tab) %}
     <p>I am tab 2.</p>
-  </div>
+  {% endcall %}
 </div>
 
 {% endblock %}


### PR DESCRIPTION
This makes our tab-bar markup a bit more [DRY](https://en.wikipedia.org/wiki/Don't_repeat_yourself) and also makes it easy for us to change what tab is active at template render time. This will hopefully make things easier for us when we need to render, for example, the nth step of a wizard interface that is embedded in a tab panel (which seems to be the case with our expertise questionnaires).