### PR TITLE
[design branch] unify .b-dropdown and .b-dropdown-alt

### DIFF
--- a/app/static/sass/_components.scss
+++ b/app/static/sass/_components.scss
@@ -112,30 +112,14 @@ textarea {
     input[type="checkbox"] { margin-right: 10px; }
 }
 
-.b-dropdown {
-    padding: 15px;
-    -webkit-appearance: none;
-    -moz-appearance: none;
-    appearance: none;
-    background-color: $white-20;
-    border: 0;
-    width: 100%;
-    font-weight: 400;
-    letter-spacing: 1px;
-    color: $white;
-    position: relative;
-    border-radius: 0;
-    box-shadow: inset 0 0 3px $gray-10;
-}
 
-
-// <label class="b-dropdown-alt" for="">
+// <div class="b-dropdown">
 //     <select>
 //         <option></option>
 //     </select>
-// </label>
+// </div>
 
-.b-dropdown-alt {
+.b-dropdown {
     width: 100%;
     display: block;
     position: relative;

--- a/app/static/sass/_find-innovator.scss
+++ b/app/static/sass/_find-innovator.scss
@@ -4,8 +4,8 @@
     background-color: $gray-70;
     padding: 20px;
 
-    .b-dropdown-alt { margin-bottom: 20px; }
-    .b-dropdown-alt:last-child { margin-bottom: 0; }
+    .b-dropdown { margin-bottom: 20px; }
+    .b-dropdown:last-child { margin-bottom: 0; }
 }
 
 .b-innovator-results {

--- a/app/templates/security/_macros_new.html
+++ b/app/templates/security/_macros_new.html
@@ -4,14 +4,14 @@
       {{ field(**kwargs)|safe }}
       {{ field.label }}
     </div>
+  {% elif field.type in ["SelectField", "CountryField"] %}
+    <div class="b-dropdown">
+      {{ field.label(class="sr-only") }}
+      {{ field(placeholder=field.label.text, **kwargs)|safe }}
+    </div>
   {% else %}
     {{ field.label(class="sr-only") }}
-    {% if field.type in ["SelectField", "CountryField"] %}
-      {% set field_class = "b-dropdown" %}
-    {% else %}
-      {% set field_class = "b-textfield" %}
-    {% endif %}
-    {{ field(class=field_class, placeholder=field.label.text, **kwargs)|safe }}
+    {{ field(class="b-textfield", placeholder=field.label.text, **kwargs)|safe }}
   {% endif %}
   {% if field.errors %}
     <ul class="list-unstyled">

--- a/app/templates/style-guide/find-innovator.html
+++ b/app/templates/style-guide/find-innovator.html
@@ -7,7 +7,7 @@
 
 <section class="b-filters">
     <form action="">
-        <label class="b-dropdown-alt" for="">
+        <label class="b-dropdown" for="">
             <select>
                 <option>Open Data</option>
                 <option>Community Engagement</option>
@@ -17,7 +17,7 @@
                 <option>Crowdsourcing</option>
             </select>
         </label>
-        <label class="b-dropdown-alt" for="">
+        <label class="b-dropdown" for="">
             <select>
                 <option>All</option>
                 <option>United Kingdom</option>

--- a/app/templates/style-guide/signup-basic-info.html
+++ b/app/templates/style-guide/signup-basic-info.html
@@ -9,12 +9,14 @@
             <p class="e-onboarding-message">Now please share some basic information about yourself,<br> so others can know who you are</p>
             <form action="" class="e-onboarding-form">
                 <input class="b-textfield" type="text" placeholder="Organization">
-                <select class="b-dropdown" name="" id="">
+                <div class="b-dropdown">
+                <select name="" id="">
                     <option value="">Type of Organization</option>
                     <option value="">Organization 1</option>
                     <option value="">Organization 2</option>
                     <option value="">Organization 3</option>
                 </select>
+                </div>
                 <input class="b-textfield" type="text" placeholder="Position">
                 <input class="b-textfield" type="text" placeholder="Location">
                 <input class="b-button" type="submit" value="Next">


### PR DESCRIPTION
This does two things:

1. Gets rid of `.b-dropdown` and
2. Renames `.b-dropdown-alt` to `.b-dropdown`.

Note that `.b-dropdown` is now styled a bit funkily on security-related pages:

![2015-10-13_11-05-05](https://cloud.githubusercontent.com/assets/124687/10458867/f7de36aa-719a-11e5-9273-f94d6006d26c.png)

But @claudioccm will fix it!