### PR TITLE
New UI for search and search results page

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -140,12 +140,12 @@ class SearchForm(Form):
     country = CountryField()
     locales = CallableChoicesSelectMultipleField(
         label=lazy_gettext('Languages'),
-        widget=ChosenSelect(multiple=True),
+        widget=Select(multiple=True),
         choices=lambda: [(l.language, l.get_language_name(get_locale()))
                          for l in LOCALES])
     expertise_domain_names = CallableChoicesSelectMultipleField(
         label=lazy_gettext('Domains of Expertise'),
-        widget=ChosenSelect(multiple=True),
+        widget=Select(multiple=True),
         choices=lambda: [(v, lazy_gettext(v)) for v in current_app.config['DOMAINS']])
     fulltext = TextField()
 

--- a/app/templates/search-results.html
+++ b/app/templates/search-results.html
@@ -1,52 +1,22 @@
-{% extends "__base__.html" %}
+{% extends "__base_ui__.html" %}
+
+{% from "_macros.html" import get_user_avatar_url %}
 
 {% block content %}
 
-<div id="new-search">
-  <a target="__email__" role="button" class="btn btn-primary" href="mailto:{{results|map(attribute='email')|join(',')}}?subject={{ gettext('Contact+request+from+the+Network+of+Innovators') }}" data-connect-to="{{results|map(attribute='email')|join(',')}}">{{ gettext('Contact all these people') }}</a>
-</div>
-
-<div class="b-results">
-	<div class="b-content-header">
-		<h1>{{ title }}{# | {{results|length}}#}</h1>
-    {% if NOI_DEPLOY == 'nhs.networkofinnovators.org' %}
-        <p>Your personalized matches from the Expo who has experience in at least one of the areas you want to learn about.</p>
-        <p><strong>{{ gettext('E-mail one or more of them to meet, network and learn something new!') }}</strong></p>
+<section class="b-innovator-results">
+  <p class="e-intro-message">Reach better decisions faster, develop solutions that create value, increase transparency and enable action.</p>
+  <div class="e-results-container">
+    {% for user, score in results %}
+    {% if user.display_in_search %}
+      <a class="e-result-item" href="{{ url_for('views.get_user', userid=user.id) }}">
+        <img src="{{ get_user_avatar_url(user) }}" alt="" class="e-picture">
+        <p class="e-name">{{ user.full_name }}</p>
+        <p class="e-job">{{ user.position }}</p>
+      </a>
     {% endif %}
-	</div>
-	<div id="result-set" class="b-results-container">
-		<ol>
-			{% for user, score in results %}
-      {% if user.display_in_search %}
-			<li class="noi b-result-item">
-				<!-- <div style="" class="noi-index">{{loop.index}}{% if DEBUG %}<br/><a href="edit/{{user.id}}">edit</a>{% endif %}</div> -->
-        {% if user.has_picture %}
-        <img class="icon" src="{{ user.picture_url }}">
-        {% endif %}
-				<div class="e-info">
-					<a class="e-name" href="/user/{{user.id}}">{{user.first_name|title}} {{user.last_name|title}}</a>
-					<div class="e-job">{{user.title or ''}} &nbsp; {{user.organization or ''}}</div> <!-- This should be limited to 76char -->
-					<div class="e-place"><i class="fa fa-map-marker"></i>{{user.city or ''}} &nbsp; {{user.country or ''}}</div>
-					<div class="e-bottom-info">
-
-            {#
-					{% if score and score > 0 %}
-						<div class="e-score">
-							<i class="fa fa-star"></i>{{score}}
-						</div>
-					{% endif %}
-          #}
-
-{#<div class="e-lang">{{ user.languages }}</div>#}
-					</div>
-				</div>
-				
-			</li>
-      {% endif %}
-			{% endfor %}
-		</ol>
-	</div>
-</div>
-
+    {% endfor %}
+  </div>
+</section>
 
 {% endblock %}

--- a/app/templates/search.html
+++ b/app/templates/search.html
@@ -1,74 +1,34 @@
-{% extends "__base__.html" %}
+{% extends "__base_ui__.html" %}
 
-{% block title %}{{ gettext('Search interface') }}{% endblock %}
+{% block title %}{{ gettext('Find Innovator') }}{% endblock %}
 
 {% block page_style_pre %}
-{#{% if request.MOBILE == False %}#}
 	<link rel="stylesheet" href="/static/chosen_v1.4.2/docsupport/style.css">
   <link rel="stylesheet" href="/static/chosen_v1.4.2/docsupport/prism.css">
   <link rel="stylesheet" href="/static/chosen_v1.4.2/chosen.css">
-{#{% endif %}#}
-  <!--<style>
-  .noi-button { margin-top: 20px; margin-left: 20px;}
-	.selector { margin-top: 20px; margin-left: 20px;}
-	ol ul li, ul ul li {
-  list-style-type: none;
-  margin: initial;
-}
-ul li {
-  list-style: initial;
-  margin-left: initial;
-  margin-bottom: initial;
-}
-	</style>-->
 {% endblock %}
 
 {% block content %}
-<div id="search-ui-page">
-<div class="container-fluid">
-  <div class="b-content-header">
-    <h1>{{ gettext('Search for Innovators') }}</h1>
-  </div>
-  
-  <div class="row">
-    <div class="col-xs-4 col-md-4">
-      <form class="b-form" action="/search" method="GET">
-
-        <label class="col-md-4 control-label" for="textarea">{{ gettext('By country') }}</label>
-        <div class="selector">
-          {{ form.country(placeholder=gettext('Choose your countries')) }}
-        </div>
-
-        <label class="col-md-4 control-label" for="textarea">{{ gettext('By language(s)') }}</label>
-        <div class="selector">
-          {{ form.locales(placeholder=gettext('Choose your languages')) }}
-        </div>
-
-        <label class="col-md-4 control-label" for="textarea">{{ gettext('By domain(s)') }}</label>
-        <div class="selector">
-          {{ form.expertise_domain_names(placeholder=gettext('Choose your fields of expertise')) }}
-        </div>
-
-    <label class="col-md-4 control-label" for="textarea">{{ gettext('By keyword(s)') }}</label>
-    <div class="selector">
-      {{ form.fulltext() }}
-      {#<input placeholder="Search for anything ..." type="text" id="fulltext" name="fulltext">#}
+<section class="b-filters">
+  <form action="{{ url_for('views.search') }}" method="GET">
+    <div class="b-dropdown">
+      <label class="sr-only" for="country">{{ gettext('By country') }}</label>
+      {{ form.country(placeholder=gettext('Choose your country')) }}
     </div>
-
-		<div>
-      <input type="submit" value="{{ gettext('Find experts') }}">
-		</div>
-
-	</form>
-
-</div> <!-- row -->
-</div>
+    <div class="b-dropdown">
+      <label class="sr-only" for="locales">{{ gettext('By language(s)') }}</label>
+      {{ form.locales(placeholder=gettext('Choose your languages')) }}
+    </div>
+    <div class="b-dropdown">
+      <label class="sr-only" for="expertise_domain_names">{{ gettext('By domain(s)') }}</label>
+      {{ form.expertise_domain_names(placeholder=gettext('Choose your fields of expertise')) }}
+    </div>
+  <input class="b-button" type="submit" value="{{ gettext('Find experts') }}">
+  </form>
+</section>
 {% endblock %}
 
 {% block page_script %}
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.4/jquery.min.js" type="text/javascript"></script>
-
-{#{% if request.MOBILE == False %}#}
 <script src="/static/chosen_v1.4.2/chosen.jquery.js" type="text/javascript"></script>
 <script src="/static/chosen_v1.4.2/docsupport/prism.js" type="text/javascript" charset="utf-8"></script>
 <script type="text/javascript">
@@ -83,8 +43,5 @@ ul li {
       $(selector).chosen(config[selector]);
     }
 </script>
-{#{% endif %}#}
-
-
 
 {% endblock %}

--- a/app/templates/search.html
+++ b/app/templates/search.html
@@ -3,6 +3,20 @@
 {% block title %}{{ gettext('Find Innovator') }}{% endblock %}
 
 {% block page_style_pre %}
+  <style>
+  /* TODO: This styling is temporary. */
+  .temp-chosen-style {
+    margin-bottom: 20px;
+  }
+
+  .temp-chosen-style select {
+    width: 100%;
+  }
+
+  .b-filters .b-button {
+    color: white;
+  }
+  </style>
 	<link rel="stylesheet" href="/static/chosen_v1.4.2/docsupport/style.css">
   <link rel="stylesheet" href="/static/chosen_v1.4.2/docsupport/prism.css">
   <link rel="stylesheet" href="/static/chosen_v1.4.2/chosen.css">
@@ -15,11 +29,11 @@
       <label class="sr-only" for="country">{{ gettext('By country') }}</label>
       {{ form.country(placeholder=gettext('Choose your country')) }}
     </div>
-    <div class="b-dropdown">
+    <div class="temp-chosen-style">
       <label class="sr-only" for="locales">{{ gettext('By language(s)') }}</label>
       {{ form.locales(placeholder=gettext('Choose your languages')) }}
     </div>
-    <div class="b-dropdown">
+    <div class="temp-chosen-style">
       <label class="sr-only" for="expertise_domain_names">{{ gettext('By domain(s)') }}</label>
       {{ form.expertise_domain_names(placeholder=gettext('Choose your fields of expertise')) }}
     </div>

--- a/app/templates/search.html
+++ b/app/templates/search.html
@@ -5,22 +5,13 @@
 {% block page_style_pre %}
   <style>
   /* TODO: This styling is temporary. */
-  .temp-chosen-style {
-    margin-bottom: 20px;
-  }
-
-  .temp-chosen-style select {
-    width: 100%;
-  }
-
   .b-filters .b-button {
     color: white;
   }
   </style>
-	<link rel="stylesheet" href="/static/chosen_v1.4.2/docsupport/style.css">
-  <link rel="stylesheet" href="/static/chosen_v1.4.2/docsupport/prism.css">
-  <link rel="stylesheet" href="/static/chosen_v1.4.2/chosen.css">
 {% endblock %}
+
+{% from "_macros.html" import get_user_avatar_url %}
 
 {% block content %}
 <section class="b-filters">
@@ -29,33 +20,33 @@
       <label class="sr-only" for="country">{{ gettext('By country') }}</label>
       {{ form.country(placeholder=gettext('Choose your country')) }}
     </div>
-    <div class="temp-chosen-style">
+    <div class="b-dropdown">
       <label class="sr-only" for="locales">{{ gettext('By language(s)') }}</label>
       {{ form.locales(placeholder=gettext('Choose your languages')) }}
     </div>
-    <div class="temp-chosen-style">
+    <div class="b-dropdown">
       <label class="sr-only" for="expertise_domain_names">{{ gettext('By domain(s)') }}</label>
       {{ form.expertise_domain_names(placeholder=gettext('Choose your fields of expertise')) }}
     </div>
   <input class="b-button" type="submit" value="{{ gettext('Find experts') }}">
   </form>
 </section>
-{% endblock %}
 
-{% block page_script %}
-<script src="/static/chosen_v1.4.2/chosen.jquery.js" type="text/javascript"></script>
-<script src="/static/chosen_v1.4.2/docsupport/prism.js" type="text/javascript" charset="utf-8"></script>
-<script type="text/javascript">
-    var config = {
-      '.chosen-select'           : {},
-      '.chosen-select-deselect'  : {allow_single_deselect:true},
-      '.chosen-select-no-single' : {disable_search_threshold:10},
-      '.chosen-select-no-results': {no_results_text:'Oops, nothing found!'},
-      '.chosen-select-width'     : {width:"95%"}
-    }
-    for (var selector in config) {
-      $(selector).chosen(config[selector]);
-    }
-</script>
+{% if results %}
+<section class="b-innovator-results">
+  <p class="e-intro-message">Reach better decisions faster, develop solutions that create value, increase transparency and enable action.</p>
+  <div class="e-results-container">
+    {% for user, score in results %}
+    {% if user.display_in_search %}
+      <a class="e-result-item" href="{{ url_for('views.get_user', userid=user.id) }}">
+        <img src="{{ get_user_avatar_url(user) }}" alt="" class="e-picture">
+        <p class="e-name">{{ user.full_name }}</p>
+        <p class="e-job">{{ user.position }}</p>
+      </a>
+    {% endif %}
+    {% endfor %}
+  </div>
+</section>
+{% endif %}
 
 {% endblock %}

--- a/app/tests/test_views.py
+++ b/app/tests/test_views.py
@@ -339,7 +339,7 @@ class ViewTests(ViewTestCase):
         self.login()
         res = self.client.get('/search')
         self.assert200(res)
-        assert "Search for Innovators" in res.data
+        assert "Find Innovator" in res.data
 
     def test_network_is_ok(self):
         self.login()
@@ -350,7 +350,7 @@ class ViewTests(ViewTestCase):
         self.login()
         res = self.client.get('/search?country=ZZ')
         self.assert200(res)
-        assert "Expertise search" in res.data
+        assert "e-results-container" in res.data
 
     def test_recent_users_is_ok(self):
         self.login()

--- a/app/views.py
+++ b/app/views.py
@@ -376,8 +376,7 @@ def search():
                         UserSkill.user_id == User.id)
 
         # TODO ordering by relevance
-        return render_template('search-results.html',
-                               title='Expertise search',
+        return render_template('search.html',
                                form=form,
                                results=query.limit(20).all())
 


### PR DESCRIPTION
~~This is a bit funky right now because the search form and results pages are currently two different views.~~ Both the search form and results are visible on the same page now.

Notes:

* I removed the "Contact all these people" button because it isn't in current mockups and it also seems to be broken.
* ~~We don't have any special styling for [chosen](https://harvesthq.github.io/chosen/) `<select>` elements so we're just using some temporary styling I added for now.~~ We've abandoned Chosen b/c it doesn't work w/ mobile.
* Also, using `b-button` for the form submit button yields a black button with dark grey text--very hard to read, so I changed the text to white via some temporary CSS.

This is what it looks like so far:

![2015-10-13_15-57-09](https://cloud.githubusercontent.com/assets/124687/10466639/3c49d56a-71c3-11e5-95bf-702b8b124e99.png)

The multi-select fields are a bit ick. Also, the down-arrow on them shouldn't be there; that's showing b/c I'm using `.b-dropdown` for them, as we don't have any other styles we can use for filters yet.