### PR TITLE
Make /activity publicly visible

### DIFF
--- a/app/templates/activity.html
+++ b/app/templates/activity.html
@@ -2,12 +2,17 @@
 
 {% from "_macros.html" import get_user_avatar_url, render_tab_bar, render_tab_panel, render_user_mailto_link %}
 
-{% set tabs = [
+{% set base_tabs = [
   ('activity', gettext('Activity')),
   ('connected', gettext('Most Connected')),
   ('complete', gettext('Most Complete')),
-  ('progress', gettext('My Profile Progress'))
 ] %}
+
+{% if current_user.is_authenticated() %}
+  {% set tabs = base_tabs + [('progress', gettext('My Profile Progress'))] %}
+{% else %}
+  {% set tabs = base_tabs %}
+{% endif %}
 
 {% set active_tab = active_tab|default(tabs[0][0]) %}
 
@@ -35,9 +40,11 @@
     <div class="e-feed-message">
       <p>{{ gettext('%(user)s shared:', user=user_link(event.user)) }}</p>
       <p>{{ event.message }}</p>
+      {% if current_user.is_authenticated() %}
       <div class="e-actions">
         {% call render_user_mailto_link(event.user, class="material-icons") %}reply{% endcall %}
       </div>
+      {% endif %}
     </div>
   {% elif event.type == 'user_joined_event' %}
     {{ user_avatar(event.user) }}
@@ -90,11 +97,13 @@
 </ul>
 {% endcall %}
 
+{% if current_user.is_authenticated() %}
 {% call render_tab_panel('progress', active_tab, class='b-profile-progress') %}
 
 {% include "_profile-progress.html" %}
 
 {% endcall %}
+{% endif %}
 
 </div> <!-- End of tab panel container -->
 

--- a/app/tests/test_views.py
+++ b/app/tests/test_views.py
@@ -166,9 +166,16 @@ class MultiStepRegistrationTests(ViewTestCase):
         self.assert404(self.client.get('/register/step/3/blah/1'))
 
 class ActivityFeedTests(ViewTestCase):
-    def test_viewing_activity_requires_full_registration(self):
-        self.login(fully_register=False)
-        self.assertRedirects(self.client.get('/activity'), '/register/step/2')
+    def test_get_is_ok(self):
+        self.assert200(self.client.get('/activity'))
+
+    def test_posting_activity_requires_login(self):
+        res = self.client.post('/activity', data=dict(
+            message=u"hello there"
+        ), follow_redirects=True)
+        self.assert200(res)
+        self.assertEqual(SharedMessageEvent.query_in_deployment().count(), 0)
+        assert 'You must log in to post a message' in res.data
 
     def test_posting_activity_requires_full_name(self):
         self.login(first_name=u'', last_name=u'')
@@ -213,6 +220,10 @@ class ActivityFeedTests(ViewTestCase):
         self.assert200(self.client.get('/activity'))
 
 class MyProfileTests(ViewTestCase):
+    def test_get_requires_full_registration(self):
+        self.login(fully_register=False)
+        self.assertRedirects(self.client.get('/me'), '/register/step/2')
+
     def test_get_is_ok(self):
         self.login()
         self.assert200(self.client.get('/me'))

--- a/app/views.py
+++ b/app/views.py
@@ -391,7 +391,6 @@ def match():
 
 
 @views.route('/activity', methods=['GET', 'POST'])
-@full_registration_required
 def activity():
     '''
     View for the activity feed of recent events.
@@ -401,7 +400,9 @@ def activity():
     shared_message_form = SharedMessageForm()
 
     if request.method == 'POST':
-        if not current_user.display_in_search:
+        if not current_user.is_authenticated():
+            flash(gettext(u'You must log in to post a message.'), 'error')
+        elif not current_user.display_in_search:
             flash(gettext(u'We need your name before you can post a message.'), 'error')
         elif shared_message_form.validate():
             data = shared_message_form.message.data


### PR DESCRIPTION
As mentioned in https://github.com/GovLab/noi2/pull/135#issuecomment-147752711, the activity page needs to be visible to logged-out users so that prospective users have some idea of what the value proposition of signing up to the site is.

UI changes to the logged-out version of this page:
* Changes to the topmost nav as mentioned in #135
* The "My Profile Progress" tab is gone
* There is no `mailto:` link on shared messages, as we don't want to expose users' email addresses so easily to spammers
