### PR TITLE
Set locale based on Accept-Languages header

### DIFF
--- a/app/factory.py
+++ b/app/factory.py
@@ -20,7 +20,7 @@ from app.forms import (NOIForgotPasswordForm,
                        NOIRegisterForm)
 from app.models import db, User, Role
 from app.views import views
-from app import style_guide
+from app import style_guide, l10n
 
 from sqlalchemy.orm.exc import NoResultFound
 
@@ -190,6 +190,7 @@ def create_app(config=None): #pylint: disable=too-many-statements
     app.config['SEARCH_DEPLOYMENTS'] = this_deployment.get('searches', []) or []
     app.config['SEARCH_DEPLOYMENTS'].append(noi_deploy)
     babel.init_app(app)
+    l10n.init_app(app)
 
     app.config['DOMAINS'] = this_deployment.get('domains',
                                                 default_deployment['domains'])

--- a/app/l10n.py
+++ b/app/l10n.py
@@ -1,12 +1,15 @@
 from flask import request
 
-import os
+DEFAULT_LANGUAGE = 'en'
 
-TRANSLATIONS = ['en'] + os.listdir('/noi/app/translations')
+TRANSLATIONS = ['es_MX']
 
 def init_app(app):
     babel = app.extensions['babel']
 
     @babel.localeselector
     def get_locale():
-        return request.accept_languages.best_match(TRANSLATIONS)
+        return request.accept_languages.best_match(
+            [DEFAULT_LANGUAGE] +
+            TRANSLATIONS
+        )

--- a/app/l10n.py
+++ b/app/l10n.py
@@ -1,0 +1,12 @@
+from flask import request
+
+import os
+
+TRANSLATIONS = ['en'] + os.listdir('/noi/app/translations')
+
+def init_app(app):
+    babel = app.extensions['babel']
+
+    @babel.localeselector
+    def get_locale():
+        return request.accept_languages.best_match(TRANSLATIONS)

--- a/app/templates/__base_new__.html
+++ b/app/templates/__base_new__.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="{{ NOI_DEPLOY|slug }}">
+<html lang="{{ get_locale().language }}" class="{{ NOI_DEPLOY|slug }}">
 <head>
     <meta charset="UTF-8">
     {% block head %}

--- a/app/tests/test_l10n.py
+++ b/app/tests/test_l10n.py
@@ -1,0 +1,15 @@
+from .test_views import ViewTestCase
+
+from app import l10n
+
+class LocalizationTests(ViewTestCase):
+    def test_locale_is_en_by_default(self):
+        res = self.client.get('/')
+        assert '<html lang="en"' in res.data
+
+    def test_locale_in_accept_language_header_is_respected(self):
+        assert 'es_MX' in l10n.TRANSLATIONS
+        res = self.client.get('/', headers={
+            'Accept-Language': 'es_MX'
+        })
+        assert '<html lang="es"' in res.data

--- a/app/tests/test_l10n.py
+++ b/app/tests/test_l10n.py
@@ -1,8 +1,15 @@
-from .test_views import ViewTestCase
+import os
 
+from .test_views import ViewTestCase
 from app import l10n
 
 class LocalizationTests(ViewTestCase):
+    def test_all_translations_exist(self):
+        dirs = os.listdir('/noi/app/translations')
+        for locale in l10n.TRANSLATIONS:
+            if locale not in dirs:
+                self.fail('Locale %s does not exist' % locale)
+
     def test_locale_is_en_by_default(self):
         res = self.client.get('/')
         assert '<html lang="en"' in res.data


### PR DESCRIPTION
This lays a foundation for fixing #148 (and partially fixes it) by adding a simple [Babel `localeselector`](https://pythonhosted.org/Flask-Babel/#flask.ext.babel.Babel.localeselector) for the app that just compares the request's `Accept-Languages` header to the available translations.

This can be manually tested by using Firefox and going to "Options -> Content -> Languages -> Choose..." and adding "Spanish / Mexico [es-mx]" to the top of the list, and then reloading any page on the site, the language of which should change to Spanish. (Unfortunately, this is hard to do in other browsers because they don't seem to support explicitly setting es-mx.)

In the future, we can add some code to the `localeselector` that inspects the user's session and/or profile to choose a better language, along with a UI on the site to change it, so that the user has even more control over the locale and we can mark #148 as resolved.
