### PR TITLE
Fix picture on 'match me' pages.

### DIFF
--- a/app/static/sass/_match-me.scss
+++ b/app/static/sass/_match-me.scss
@@ -11,14 +11,14 @@
     }
 
     .e-match-item header {
-        display: flex;
         align-items: center;
     }
 
     .e-picture {
-        flex: 1;
         padding: 20px;
         position: relative;
+        max-width: 100%;
+        text-align: center;
 
         img {
             max-width: 100%;
@@ -48,7 +48,7 @@
     }
 
     .e-info {
-        flex: 3;
+        text-align: center;
     }
 
     .e-name,


### PR DESCRIPTION
This fixes #153, but it does so by moving the user information *underneath* the profile picture instead of to the right side of it, because I wasn't sure how to make the fix via the flexbox model:

![2015-10-15_8-25-58](https://cloud.githubusercontent.com/assets/124687/10513695/4ca924ba-7317-11e5-8159-20d72d8810ed.png)

@claudioccm, if you have a better fix for this, feel free to revert this commit on the design branch and do it!