### PR TITLE
Initial implementation of tutorial popups.

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -42,6 +42,7 @@ main_css = Bundle('css/vendor/bootstrap.css',
 assets.register('main_css', main_css)
 
 main_js = Bundle('js/main.js',
+                 'js/tutorial.js',
                  'vendor/bootstrap/js/alert.js',
                  'vendor/bootstrap/js/modal.js',
                  'vendor/bootstrap/js/tab.js',

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -24,14 +24,4 @@ $(document).ready(function () {
       });
     }
   });
-
-  // Advance tutorial steps
-  $("[data-tutorial-step]").click(function (evt) {
-    var step = $(evt.target).data('tutorial-step');
-    if (step) {
-      $.post('/tutorial', {
-        'step': step
-      });
-    }
-  });
 });

--- a/app/static/js/tutorial.js
+++ b/app/static/js/tutorial.js
@@ -2,23 +2,31 @@ $(function() {
   var VERTICAL_INSET_PX = 8;
   var currStep = $("meta[name=current-tutorial-step]").attr('content');
 
+  function positionPopup(popup, target) {
+    var topArrow = $('.e-top-arrow', popup).css({left: '0'});
+    var top = Math.floor(target.offset().top + target.outerHeight() +
+                         topArrow.outerHeight() - VERTICAL_INSET_PX);
+    var left = Math.floor(target.offset().left - topArrow.offset().left +
+                          target.width() / 2 - topArrow.outerWidth() / 2);
+    popup.css({top: top + 'px'});
+    topArrow.css({left: left + 'px'});
+  }
+
   function showPopup(id) {
     var target = $("[data-tutorial-target='" + id + "']");
     var popup = $("#tutorial-" + id);
-    var topArrow = $('.e-top-arrow', popup);
-    var top, left;
+    var position = positionPopup.bind(null, popup, target);
 
     if (!target.length) return;
 
     popup.addClass('m-active');
+    position();
+    $(window).on('resize.tutorial.popup', position);
+  }
 
-    top = Math.floor(target.offset().top + target.outerHeight() +
-                     topArrow.outerHeight() - VERTICAL_INSET_PX);
-    left = Math.floor(target.offset().left - topArrow.offset().left +
-                      target.width() / 2);
-
-    popup.css({top: top + 'px'});
-    topArrow.css({left: left + 'px'});
+  function hidePopup(popup) {
+    popup.removeClass('m-active');
+    $(window).off('resize.tutorial.popup');
   }
 
   function postTutorialStep(step) {
@@ -30,7 +38,7 @@ $(function() {
   // Advance tutorial steps
   $("[data-tutorial-step]").click(function (evt) {
     var step = $(evt.target).data('tutorial-step');
-    $(this).closest('.b-tutorial-box').removeClass('m-active');
+    hidePopup($(this).closest('.b-tutorial-box'));
     if (step) {
       postTutorialStep(step);
       showPopup(step);

--- a/app/static/js/tutorial.js
+++ b/app/static/js/tutorial.js
@@ -37,7 +37,7 @@ $(function() {
 
   // Advance tutorial steps
   $("[data-tutorial-step]").click(function (evt) {
-    var step = $(evt.target).data('tutorial-step');
+    var step = $(this).data('tutorial-step');
     hidePopup($(this).closest('.b-tutorial-box'));
     if (step) {
       postTutorialStep(step);

--- a/app/static/js/tutorial.js
+++ b/app/static/js/tutorial.js
@@ -15,7 +15,7 @@ $(function() {
   function showPopup(id) {
     var target = $("[data-tutorial-target='" + id + "']");
     var popup = $("#tutorial-" + id);
-    var position = positionPopup.bind(null, popup, target);
+    var position = $.proxy(positionPopup, null, popup, target);
 
     if (!target.length) return;
 

--- a/app/static/js/tutorial.js
+++ b/app/static/js/tutorial.js
@@ -1,0 +1,46 @@
+$(function() {
+  var VERTICAL_INSET_PX = 8;
+  var currStep = $("meta[name=current-tutorial-step]").attr('content');
+
+  function showPopup(id) {
+    var target = $("[data-tutorial-target='" + id + "']");
+    var popup = $("#tutorial-" + id);
+    var topArrow = $('.e-top-arrow', popup);
+    var top, left;
+
+    if (!target.length) return;
+
+    popup.addClass('m-active');
+
+    top = Math.floor(target.offset().top + target.outerHeight() +
+                     topArrow.outerHeight() - VERTICAL_INSET_PX);
+    left = Math.floor(target.offset().left - topArrow.offset().left +
+                      target.width() / 2);
+
+    popup.css({top: top + 'px'});
+    topArrow.css({left: left + 'px'});
+  }
+
+  function postTutorialStep(step) {
+    $.post('/tutorial', {
+      'step': step
+    });
+  }
+
+  // Advance tutorial steps
+  $("[data-tutorial-step]").click(function (evt) {
+    var step = $(evt.target).data('tutorial-step');
+    $(this).closest('.b-tutorial-box').removeClass('m-active');
+    if (step) {
+      postTutorialStep(step);
+      showPopup(step);
+    }
+  });
+
+  // For debugging only.
+  window._resetTutorial = function() {
+    postTutorialStep(1);
+  }
+
+  if (currStep) showPopup(currStep);
+});

--- a/app/static/sass/_tutorial.scss
+++ b/app/static/sass/_tutorial.scss
@@ -11,6 +11,11 @@
 
     &.m-active { display: block; }
 
+    &.on-right-side {
+        margin-left: 14vw;
+        margin-right: 0;
+    }
+
     .e-top-arrow {
         width: 0;
         height: 0;

--- a/app/static/sass/_tutorial.scss
+++ b/app/static/sass/_tutorial.scss
@@ -23,7 +23,11 @@
         border-right: 20px solid transparent;
         border-bottom: 20px solid $teal;
         position: absolute;
-        top: -20px;
+
+        // Ensure a tiny amount of overlap between the
+        // arrow and the box to ensure browsers never render
+        // any space in between them.
+        top: -19px;
     }
 
     p {

--- a/app/templates/__base_ui__.html
+++ b/app/templates/__base_ui__.html
@@ -9,7 +9,7 @@
         <div class="e-user-utils">
           {% if current_user.is_authenticated() %}
             <a href="#post-a-message" data-toggle="modal"><span class="e-post material-icons">chat</span></a>
-            <a href="#profile-summary" data-toggle="modal"><img class="e-user-picture" src="{{ get_user_avatar_url(current_user) }}"></a>
+            <a href="#profile-summary" data-toggle="modal"><img class="e-user-picture" data-tutorial-target="2" src="{{ get_user_avatar_url(current_user) }}"></a>
           {% else %}
             <a href="{{ url_for('views.about_page') }}"><span class="e-post material-icons">info</span></a>
             <a href="{{ url_for_security('login') }}"><span class="e-post material-icons">account_circle</span></a>
@@ -21,7 +21,7 @@
                 <span class="material-icons">home</span>
                 {{ gettext('Home') }}
             </a>
-            <a href="{{ url_for('views.match') }}" class="e-nav-item">
+            <a href="{{ url_for('views.match') }}" class="e-nav-item" data-tutorial-target="1">
                 <span class="material-icons">group</span>
                 {{ gettext('Match Me') }}
             </a>

--- a/app/templates/__base_ui__.html
+++ b/app/templates/__base_ui__.html
@@ -9,7 +9,7 @@
         <div class="e-user-utils">
           {% if current_user.is_authenticated() %}
             <a href="#post-a-message" data-toggle="modal"><span class="e-post material-icons">chat</span></a>
-            <a href="#profile-summary" data-toggle="modal"><img class="e-user-picture" data-tutorial-target="2" src="{{ get_user_avatar_url(current_user) }}"></a>
+            <a href="#profile-summary" data-toggle="modal"><img class="e-user-picture" data-tutorial-target="3" src="{{ get_user_avatar_url(current_user) }}"></a>
           {% else %}
             <a href="{{ url_for('views.about_page') }}"><span class="e-post material-icons">info</span></a>
             <a href="{{ url_for_security('login') }}"><span class="e-post material-icons">account_circle</span></a>
@@ -25,7 +25,7 @@
                 <span class="material-icons">group</span>
                 {{ gettext('Match Me') }}
             </a>
-            <a href="{{ url_for('views.search') }}" class="e-nav-item">
+            <a href="{{ url_for('views.search') }}" class="e-nav-item" data-tutorial-target="2">
                 <span class="material-icons">search</span>
                 {{ gettext('Find Innovator') }}
             </a>

--- a/app/templates/activity.html
+++ b/app/templates/activity.html
@@ -116,17 +116,25 @@
 {% if current_user.is_authenticated() %}
 <div class="b-tutorial-box" id="tutorial-1">
       <div class="e-top-arrow"></div>
-      <p>Welcome <strong>{{ current_user.first_name }}</strong>!</p>
-      <p>You can <strong>meet your top matches</strong> based on your skills and interests.</p>
-      <button class="b-button" data-tutorial-step="2">Next</button>
-      <div class="e-counter">1/2</div>
+      <p>{{ gettext('Welcome <strong>%(first_name)s</strong>!', first_name=current_user.first_name) }}</p>
+      <p>{{ gettext('You can <strong>meet your top matches</strong> based on your skills and interests.') }}</p>
+      <button class="b-button" data-tutorial-step="2">{{ gettext('Next') }}</button>
+      <div class="e-counter">1/3</div>
 </div>
 
-<div class="b-tutorial-box on-right-side" id="tutorial-2">
+<div class="b-tutorial-box" id="tutorial-2">
       <div class="e-top-arrow"></div>
-      <p>You can access your profile and log out and stuff here.</p>
-      <button class="b-button" data-tutorial-step="3">Thanks</button>
-      <div class="e-counter">2/2</div>
+      <p>{{ gettext('You can also <strong>browse innovators</strong> by skill area!') }}</p>
+      <button class="b-button" data-tutorial-step="3">{{ gettext('Next') }}</button>
+      <div class="e-counter">2/3</div>
+</div>
+
+<div class="b-tutorial-box on-right-side" id="tutorial-3">
+      <div class="e-top-arrow"></div>
+      <p>{{ gettext("Don't forget to <strong>update your profile</strong>.") }}</p>
+      <p>{{ gettext("The more questions you answer, the more relevant your matches.") }}</p>
+      <button class="b-button" data-tutorial-step="4">{{ gettext("OK") }}</button>
+      <div class="e-counter">3/3</div>
 </div>
 {% endif %}
 

--- a/app/templates/activity.html
+++ b/app/templates/activity.html
@@ -2,6 +2,12 @@
 
 {% from "_macros.html" import get_user_avatar_url, render_tab_bar, render_tab_panel, render_user_mailto_link %}
 
+{% block page_style_pre %}
+  {% if current_user.is_authenticated() %}
+  <meta name="current-tutorial-step" content="{% if current_user.tutorial_step %}{{ current_user.tutorial_step }}{% else %}1{% endif %}">
+  {% endif %}
+{% endblock %}
+
 {% set base_tabs = [
   ('activity', gettext('Activity')),
   ('connected', gettext('Most Connected')),
@@ -106,5 +112,22 @@
 {% endif %}
 
 </div> <!-- End of tab panel container -->
+
+{% if current_user.is_authenticated() %}
+<div class="b-tutorial-box" id="tutorial-1">
+      <div class="e-top-arrow"></div>
+      <p>Welcome <strong>{{ current_user.first_name }}</strong>!</p>
+      <p>You can <strong>meet your top matches</strong> based on your skills and interests.</p>
+      <button class="b-button" data-tutorial-step="2">Next</button>
+      <div class="e-counter">1/2</div>
+</div>
+
+<div class="b-tutorial-box on-right-side" id="tutorial-2">
+      <div class="e-top-arrow"></div>
+      <p>You can access your profile and log out and stuff here.</p>
+      <button class="b-button" data-tutorial-step="3">Thanks</button>
+      <div class="e-counter">2/2</div>
+</div>
+{% endif %}
 
 {% endblock %}

--- a/app/templates/style-guide/activity.html
+++ b/app/templates/style-guide/activity.html
@@ -73,7 +73,7 @@
     </footer>
 </section>
 
-<div class="b-tutorial-box" style="top: 200px; display: block"> <!-- Inline styles from JS -->
+<div class="b-tutorial-box" style="top: 200px;"> <!-- Inline styles from JS -->
     <div class="e-top-arrow" style="left: 65px;"></div> <!-- Inline styles from JS -->
     <p>Welcome <strong>Simon</strong>!</p>
     <p>You can <strong>meet your top matches</strong> based on your skills and interests</p>

--- a/app/templates/style-guide/base.html
+++ b/app/templates/style-guide/base.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    {% block page_style_pre %}{% endblock %}
     <title>{% block title %}Network of Innovators | The GovLab{% endblock %}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <meta name="csrf-token" content="{{ csrf_token() }}">

--- a/app/templates/style-guide/tutorial.html
+++ b/app/templates/style-guide/tutorial.html
@@ -1,0 +1,29 @@
+{% extends "style-guide/base.html" %}
+
+{% block page_style_pre %}
+<meta name="current-tutorial-step" content="1">
+<style>
+p { text-align: center; }
+</style>
+{% endblock %}
+
+{% block content %}
+<p data-tutorial-target="1" style="text-align: center">I am the target for step 1.</p>
+
+<span data-tutorial-target="2" style="float: right">Hello!</span>
+
+<div class="b-tutorial-box" id="tutorial-1">
+    <div class="e-top-arrow"></div>
+    <p>We use some custom jQuery to do tutorial popovers.</p>
+    <p>Give a page element a <code>data-tutorial-target</code> attribute to point at it.</p>
+    <button class="b-button" data-tutorial-step="2">Next</button>
+    <div class="e-counter">1/2</div>
+</div>
+
+<div class="b-tutorial-box on-right-side" id="tutorial-2">
+    <div class="e-top-arrow"></div>
+    <p>Add <code>.on-right-side</code> to point at things way over here.</p>
+    <button class="b-button" data-tutorial-step="3">OK</button>
+    <div class="e-counter">2/2</div>
+</div>
+{% endblock %}


### PR DESCRIPTION
<img width="334" alt="screen shot 2015-10-16 at 4 46 55 pm" src="https://cloud.githubusercontent.com/assets/124687/10552981/935693a2-7425-11e5-9010-1fb86f9e20ab.png">

Notes:

* ~~There's frequently a one-pixel gap between the top arrow and the tutorial box content on my screen, which is really annoying.~~ Fixed!
* The turquoise color of the popup and the blue of the nav toolbar are very similar, so it's hard to see the popup arrow when it's pointing at the "Match Me" button.
* ~~If the window is resized, the tutorial popup's position doesn't adjust, so it's now pointing at potentially the wrong place.~~ Fixed!
* `_resetTutorial()` can be called from the browser console to reset the tutorial state on the server-side. Eventually it'd be nice to have a control for this from a settings page or somesuch.
* There's no ARIA markup for this at all and it's probably not particularly accessible right now.
