### PR TITLE
Add a locale selector widget on the homepage.

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -2,7 +2,7 @@
 NoI forms
 '''
 
-from app import LOCALES
+from app import LOCALES, l10n
 from app.models import User
 
 from flask import current_app
@@ -19,7 +19,8 @@ from flask_security.forms import (LoginForm, RegisterForm,
 from flask_babel import lazy_gettext
 from wtforms_alchemy import model_form_factory, CountryField
 from wtforms import StringField, PasswordField, BooleanField, SubmitField
-from wtforms.fields import SelectMultipleField, TextField, TextAreaField
+from wtforms.fields import (SelectMultipleField, TextField, TextAreaField,
+                            SelectField)
 from wtforms.widgets import Select
 from wtforms.validators import ValidationError, Required
 
@@ -136,6 +137,21 @@ class SearchForm(Form):
         widget=Select(multiple=True),
         choices=lambda: [(v, lazy_gettext(v)) for v in current_app.config['DOMAINS']])
     fulltext = TextField()
+
+
+class ChangeLocaleForm(Form):
+    '''
+    Form that allows the user to change the locale of the site.
+    '''
+
+    locale = SelectField(
+        label=lazy_gettext('Language'),
+        default=lambda: str(get_locale()),
+        choices=[
+            (str(l), l.get_display_name() or l.english_name or str(l))
+            for l in l10n.VALID_LOCALES
+        ]
+    )
 
 
 class NOIForgotPasswordForm(ForgotPasswordForm):

--- a/app/l10n.py
+++ b/app/l10n.py
@@ -1,10 +1,13 @@
-from flask import request
+from flask import request, session
 import flask_babel
 from speaklater import make_lazy_string
+from babel import Locale
 
-DEFAULT_LANGUAGE = 'en'
+DEFAULT_LOCALE = Locale('en')
 
-TRANSLATIONS = ['es_MX']
+TRANSLATIONS = [Locale('es_MX')]
+VALID_LOCALES = [DEFAULT_LOCALE] + TRANSLATIONS
+VALID_LOCALE_CODES = [str(l) for l in VALID_LOCALES]
 
 
 def configure_app(app):
@@ -84,11 +87,14 @@ def init_app(app):
 
     @babel.localeselector
     def get_locale():
-        return request.accept_languages.best_match(
-            [DEFAULT_LANGUAGE] +
-            TRANSLATIONS
-        )
+        if 'locale' in session and session['locale'] in VALID_LOCALE_CODES:
+            return session['locale']
+        return request.accept_languages.best_match(VALID_LOCALE_CODES)
 
     # This forces any "lazy strings" like those returned by
     # lazy_gettext() to be evaluated.
     app.login_manager.localize_callback = unicode
+
+def change_session_locale(locale, session=session):
+    if locale in VALID_LOCALE_CODES:
+        session['locale'] = str(locale)

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -24,4 +24,8 @@ $(document).ready(function () {
       });
     }
   });
+
+  $('form[data-submit-on-change]').change(function() {
+    this.submit();
+  });
 });

--- a/app/templates/main.html
+++ b/app/templates/main.html
@@ -18,10 +18,24 @@
           <p>Seeking new and effective ways to solve problems and make decisions?</p>
 
           <br>
+
           <p>
             <a class="b-button" href="{{ url_for_security('register') }}">Get Started</a>
           </p>
         </section>
+
+            <form method="POST" action="{{ url_for('views.change_locale') }}" class="e-onboarding-form" data-submit-on-change>
+              {{ change_locale_form.hidden_tag() }}
+              <div class="b-dropdown">
+                {{ change_locale_form.locale.label(class="sr-only") }}
+                {{ change_locale_form.locale() }}
+              </div>
+
+              <noscript>
+                <input class="b-button" type="submit" value="{{ gettext('Change Language') }}">
+              </noscript>
+
+            </form>
 
         <footer>
           <p class="e-signup">

--- a/app/tests/test_l10n.py
+++ b/app/tests/test_l10n.py
@@ -14,7 +14,7 @@ def test_flask_security_strings_do_not_interpolate():
 def test_all_translations_exist():
     dirs = os.listdir('/noi/app/translations')
     for locale in l10n.TRANSLATIONS:
-        if locale not in dirs:
+        if str(locale) not in dirs:
             raise Exception('Locale %s does not exist' % locale)
 
 class LocalizationTests(ViewTestCase):
@@ -22,8 +22,15 @@ class LocalizationTests(ViewTestCase):
         res = self.client.get('/')
         assert '<html lang="en"' in res.data
 
+    def test_locale_in_session_is_respected(self):
+        assert 'es_MX' in l10n.VALID_LOCALE_CODES
+        with self.client.session_transaction() as sess:
+            l10n.change_session_locale('es_MX', session=sess)
+        res = self.client.get('/')
+        assert '<html lang="es"' in res.data
+
     def test_locale_in_accept_language_header_is_respected(self):
-        assert 'es_MX' in l10n.TRANSLATIONS
+        assert 'es_MX' in l10n.VALID_LOCALE_CODES
         res = self.client.get('/', headers={
             'Accept-Language': 'es_MX'
         })

--- a/app/tests/test_views.py
+++ b/app/tests/test_views.py
@@ -382,6 +382,19 @@ class ViewTests(ViewTestCase):
     def test_main_page_is_ok(self):
         self.assert200(self.client.get('/'))
 
+    def test_changing_locale_to_invalid_is_bad_request(self):
+        res = self.client.post('/change-locale', data={
+            'locale': 'lol'
+        })
+        self.assert400(res)
+
+    def test_changing_locale_works(self):
+        res = self.client.post('/change-locale', data={
+            'locale': 'es_MX'
+        }, follow_redirects=True)
+        self.assert200(res)
+        assert '<html lang="es"' in res.data
+
     def test_about_page_is_ok(self):
         self.assert200(self.client.get('/about'))
 

--- a/app/views.py
+++ b/app/views.py
@@ -9,12 +9,12 @@ from flask import (Blueprint, render_template, request, flash,
 from flask_babel import lazy_gettext, gettext
 from flask_login import login_required, current_user
 
-from app import QUESTIONNAIRES_BY_ID, MIN_QUESTIONS_TO_JOIN, LEVELS
+from app import QUESTIONNAIRES_BY_ID, MIN_QUESTIONS_TO_JOIN, LEVELS, l10n
 from app.models import (db, User, UserLanguage, UserExpertiseDomain,
                         UserSkill, Event, SharedMessageEvent)
 
 from app.forms import (UserForm, SearchForm, SharedMessageForm,
-                       RegisterStep2Form)
+                       RegisterStep2Form, ChangeLocaleForm)
 
 from sqlalchemy import func, desc
 from sqlalchemy.dialects.postgres import array
@@ -63,7 +63,8 @@ def main_page():
     if current_user.is_authenticated():
         return redirect(url_for('views.activity'))
     else:
-        return render_template('main.html', SKIP_NAV_BAR=False)
+        return render_template('main.html',
+                               change_locale_form=ChangeLocaleForm())
 
 
 @views.route('/about')
@@ -502,3 +503,18 @@ def feedback():
     Feedback page.
     '''
     return render_template('feedback.html', **{})
+
+@views.route('/change-locale', methods=['POST'])
+def change_locale():
+    '''
+    Change the user's current locale for interacting with the site.
+    '''
+
+    change_locale_form=ChangeLocaleForm()
+
+    if change_locale_form.validate():
+        l10n.change_session_locale(change_locale_form.locale.data)
+    else:
+        abort(400)
+
+    return redirect(request.referrer or '/')


### PR DESCRIPTION
This fixes #148.

Right now it looks like a fairly gross select widget at the bottom of the homepage:

![2015-10-20_9-02-20](https://cloud.githubusercontent.com/assets/124687/10607716/62a03092-7709-11e5-82bd-df5616aeca3b.png)

The gray discoloration is due to #141. The `es_MX` is apparently because that locale has a ['display_name`](http://babel.pocoo.org/docs/api/core/#babel.core.Locale.display_name) of `None`, so I'm falling back to the locale code. We should probably file a separate issue for that after this lands.