### PR TITLE
Infinite scrolling

### DIFF
--- a/app/static/sass/_activity.scss
+++ b/app/static/sass/_activity.scss
@@ -66,6 +66,14 @@
         margin-right: 20px;
     }
 
+    .e-load-more {
+        padding: 20px;
+        text-align: center;
+        .material-icons {
+            font-size: 48px;
+        }
+    }
+
     .e-feed-message {
         -webkit-box-flex: 1;   /* OLD - iOS 6-, Safari 3.1-6 */
         -webkit-flex: 1;       /* Safari 6.1+. iOS 7.1+, BB10 */

--- a/app/static/vendor/jquery.jscroll.js
+++ b/app/static/vendor/jquery.jscroll.js
@@ -1,0 +1,219 @@
+/*!
+ * jScroll - jQuery Plugin for Infinite Scrolling / Auto-Paging
+ * http://jscroll.com/
+ *
+ * Copyright 2011-2013, Philip Klauzinski
+ * http://klauzinski.com/
+ * Dual licensed under the MIT and GPL Version 2 licenses.
+ * http://jscroll.com/#license
+ * http://www.opensource.org/licenses/mit-license.php
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * @author Philip Klauzinski
+ * @version 2.3.4
+ * @requires jQuery v1.4.3+
+ * @preserve
+ */
+(function($) {
+
+    'use strict';
+
+    // Define the jscroll namespace and default settings
+    $.jscroll = {
+        defaults: {
+            debug: false,
+            autoTrigger: true,
+            autoTriggerUntil: false,
+            loadingHtml: '<small>Loading...</small>',
+            padding: 0,
+            nextSelector: 'a:last',
+            contentSelector: '',
+            pagingSelector: '',
+            callback: false
+        }
+    };
+
+    // Constructor
+    var jScroll = function($e, options) {
+
+        // Private vars and methods
+        var _data = $e.data('jscroll'),
+            _userOptions = (typeof options === 'function') ? { callback: options } : options,
+            _options = $.extend({}, $.jscroll.defaults, _userOptions, _data || {}),
+            _isWindow = ($e.css('overflow-y') === 'visible'),
+            _$next = $e.find(_options.nextSelector).first(),
+            _$window = $(window),
+            _$body = $('body'),
+            _$scroll = _isWindow ? _$window : $e,
+            _nextHref = $.trim(_$next.attr('href') + ' ' + _options.contentSelector),
+
+            // Check if a loading image is defined and preload
+            _preloadImage = function() {
+                var src = $(_options.loadingHtml).filter('img').attr('src');
+                if (src) {
+                    var image = new Image();
+                    image.src = src;
+                }
+            },
+
+            // Wrap inner content, if it isn't already
+            _wrapInnerContent = function() {
+                if (!$e.find('.jscroll-inner').length) {
+                    $e.contents().wrapAll('<div class="jscroll-inner" />');
+                }
+            },
+
+            // Find the next link's parent, or add one, and hide it
+            _nextWrap = function($next) {
+                var $parent;
+                if (_options.pagingSelector) {
+                    $next.closest(_options.pagingSelector).hide();
+                } else {
+                    $parent = $next.parent().not('.jscroll-inner,.jscroll-added').addClass('jscroll-next-parent').hide();
+                    if (!$parent.length) {
+                        $next.wrap('<div class="jscroll-next-parent" />').parent().hide();
+                    }
+                }
+            },
+
+            // Remove the jscroll behavior and data from an element
+            _destroy = function() {
+                return _$scroll.unbind('.jscroll')
+                    .removeData('jscroll')
+                    .find('.jscroll-inner').children().unwrap()
+                    .filter('.jscroll-added').children().unwrap();
+            },
+
+            // Observe the scroll event for when to trigger the next load
+            _observe = function() {
+                _wrapInnerContent();
+                var $inner = $e.find('div.jscroll-inner').first(),
+                    data = $e.data('jscroll'),
+                    borderTopWidth = parseInt($e.css('borderTopWidth'), 10),
+                    borderTopWidthInt = isNaN(borderTopWidth) ? 0 : borderTopWidth,
+                    iContainerTop = parseInt($e.css('paddingTop'), 10) + borderTopWidthInt,
+                    iTopHeight = _isWindow ? _$scroll.scrollTop() : $e.offset().top,
+                    innerTop = $inner.length ? $inner.offset().top : 0,
+                    iTotalHeight = Math.ceil(iTopHeight - innerTop + _$scroll.height() + iContainerTop);
+
+                if (!data.waiting && iTotalHeight + _options.padding >= $inner.outerHeight()) {
+                    //data.nextHref = $.trim(data.nextHref + ' ' + _options.contentSelector);
+                    _debug('info', 'jScroll:', $inner.outerHeight() - iTotalHeight, 'from bottom. Loading next request...');
+                    return _load();
+                }
+            },
+
+            // Check if the href for the next set of content has been set
+            _checkNextHref = function(data) {
+                data = data || $e.data('jscroll');
+                if (!data || !data.nextHref) {
+                    _debug('warn', 'jScroll: nextSelector not found - destroying');
+                    _destroy();
+                    return false;
+                } else {
+                    _setBindings();
+                    return true;
+                }
+            },
+
+            _setBindings = function() {
+                var $next = $e.find(_options.nextSelector).first();
+                if (!$next.length) {
+                    return;
+                }
+                if (_options.autoTrigger && (_options.autoTriggerUntil === false || _options.autoTriggerUntil > 0)) {
+                    _nextWrap($next);
+                    if (_$body.height() <= _$window.height()) {
+                        _observe();
+                    }
+                    _$scroll.unbind('.jscroll').bind('scroll.jscroll', function() {
+                        return _observe();
+                    });
+                    if (_options.autoTriggerUntil > 0) {
+                        _options.autoTriggerUntil--;
+                    }
+                } else {
+                    _$scroll.unbind('.jscroll');
+                    $next.bind('click.jscroll', function() {
+                        _nextWrap($next);
+                        _load();
+                        return false;
+                    });
+                }
+            },
+
+            // Load the next set of content, if available
+            _load = function() {
+                var $inner = $e.find('div.jscroll-inner').first(),
+                    data = $e.data('jscroll');
+
+                data.waiting = true;
+                $inner.append('<div class="jscroll-added" />')
+                    .children('.jscroll-added').last()
+                    .html('<div class="jscroll-loading">' + _options.loadingHtml + '</div>');
+
+                return $e.animate({scrollTop: $inner.outerHeight()}, 0, function() {
+                    $inner.find('div.jscroll-added').last().load(data.nextHref, function(r, status) {
+                        if (status === 'error') {
+                            return _destroy();
+                        }
+                        var $next = $(this).find(_options.nextSelector).first();
+                        data.waiting = false;
+                        data.nextHref = $next.attr('href') ? $.trim($next.attr('href') + ' ' + _options.contentSelector) : false;
+                        $('.jscroll-next-parent', $e).remove(); // Remove the previous next link now that we have a new one
+                        _checkNextHref();
+                        if (_options.callback) {
+                            _options.callback.call(this);
+                        }
+                        _debug('dir', data);
+                    });
+                });
+            },
+
+            // Safe console debug - http://klauzinski.com/javascript/safe-firebug-console-in-javascript
+            _debug = function(m) {
+                if (_options.debug && typeof console === 'object' && (typeof m === 'object' || typeof console[m] === 'function')) {
+                    if (typeof m === 'object') {
+                        var args = [];
+                        for (var sMethod in m) {
+                            if (typeof console[sMethod] === 'function') {
+                                args = (m[sMethod].length) ? m[sMethod] : [m[sMethod]];
+                                console[sMethod].apply(console, args);
+                            } else {
+                                console.log.apply(console, args);
+                            }
+                        }
+                    } else {
+                        console[m].apply(console, Array.prototype.slice.call(arguments, 1));
+                    }
+                }
+            };
+
+        // Initialization
+        $e.data('jscroll', $.extend({}, _data, {initialized: true, waiting: false, nextHref: _nextHref}));
+        _wrapInnerContent();
+        _preloadImage();
+        _setBindings();
+
+        // Expose API methods via the jQuery.jscroll namespace, e.g. $('sel').jscroll.method()
+        $.extend($e.jscroll, {
+            destroy: _destroy
+        });
+        return $e;
+    };
+
+    // Define the jscroll plugin method and loop
+    $.fn.jscroll = function(m) {
+        return this.each(function() {
+            var $this = $(this),
+                data = $this.data('jscroll'), jscroll;
+
+            // Instantiate jScroll on this element if it hasn't been already
+            if (data && data.initialized) {
+                return;
+            }
+            jscroll = new jScroll($this, m);
+        });
+    };
+
+})(jQuery);

--- a/app/templates/_activity_events.html
+++ b/app/templates/_activity_events.html
@@ -1,0 +1,42 @@
+{% from "_macros.html" import render_user_mailto_link %}
+{% from "_activity_macros.html" import user_link, user_avatar %}
+
+<ul class="e-activity-feed-container">
+{% for event in events.items %}
+  <li class="e-feed-item">
+  <time datetime="{{ event.created_at }}"></time>
+  {% if event.type == 'shared_message' %}
+    {{ user_avatar(event.user) }}
+    <div class="e-feed-message">
+      <p>{{ gettext('%(user)s shared:', user=user_link(event.user)) }}</p>
+      <p>{{ event.message }}</p>
+      {% if current_user.is_authenticated() %}
+      <div class="e-actions">
+        {% call render_user_mailto_link(event.user) %}<span class="material-icons">reply</span> <span class="e-action-label">{{ gettext("Reply via e-mail") }}</span>{% endcall %}
+      </div>
+      {% endif %}
+    </div>
+  {% elif event.type == 'user_joined_event' %}
+    {{ user_avatar(event.user) }}
+    <div class="e-feed-message">
+      <p>{{ gettext('%(user)s joined NOI.', user=user_link(event.user)) }}</p>
+    </div>
+  {% elif event.type == 'connection_event' %}
+    <div class="e-feed-message">
+      <p>{{ ngettext('+%(num)d new connection made in NOI.', '+%(num)d new connections made in NOI.', event.emails.count()) }}</p>
+      <p>{{ gettext('%(total)s connections!', total=event.total_connections) }}</p>
+    </div>
+  {% else %}
+    <div class="e-feed-message">
+      UNKNOWN EVENT TYPE: {{ event.type }}
+    </div>
+  {% endif %}
+  </li>
+{% endfor %}
+</ul>
+
+{% if events.has_next %}
+<div class="e-load-more">
+  <a href="{{ url_for('views.activity_page', pageid=events.next_num) }}" class="material-icons">expand_more</a>
+</div>
+{% endif %}

--- a/app/templates/_activity_macros.html
+++ b/app/templates/_activity_macros.html
@@ -1,0 +1,9 @@
+{% from "_macros.html" import get_user_avatar_url %}
+
+{% macro user_link(user) -%}
+<strong><a href="{{ url_for('views.get_user', userid=user.id) }}">{{ user.full_name }}</a></strong>
+{%- endmacro %}
+
+{% macro user_avatar(user) -%}
+<a href="{{ url_for('views.get_user', userid=user.id) }}"><img class="e-user-picture" src="{{ get_user_avatar_url(user) }}" alt=""></a>
+{%- endmacro %}

--- a/app/templates/activity.html
+++ b/app/templates/activity.html
@@ -109,6 +109,7 @@
 <script>
 $(function() {
   $('#activity').jscroll({
+    nextSelector: '.e-load-more a',
     loadingHtml: '<div class="e-load-more">' +
                  {{ gettext("Loading...")|tojson }} +
                  '</div>',

--- a/app/templates/activity.html
+++ b/app/templates/activity.html
@@ -1,6 +1,7 @@
 {% extends "__base_ui__.html" %}
 
-{% from "_macros.html" import get_user_avatar_url, render_tab_bar, render_tab_panel, render_user_mailto_link %}
+{% from "_macros.html" import render_tab_bar, render_tab_panel %}
+{% from "_activity_macros.html" import user_link, user_avatar %}
 
 {% block page_style_pre %}
   {% if current_user.is_authenticated() %}
@@ -28,48 +29,8 @@
 
 <div> <!-- Start of tab panel container -->
 
-{% macro user_link(user) -%}
-<strong><a href="{{ url_for('views.get_user', userid=user.id) }}">{{ user.full_name }}</a></strong>
-{%- endmacro %}
-
-{% macro user_avatar(user) -%}
-<a href="{{ url_for('views.get_user', userid=user.id) }}"><img class="e-user-picture" src="{{ get_user_avatar_url(user) }}" alt=""></a>
-{%- endmacro %}
-
 {% call render_tab_panel('activity', active_tab, class='b-activity-feed') %}
-  <ul class="e-activity-feed-container">
-{% for event in events %}
-  <li class="e-feed-item">
-  <time datetime="{{ event.created_at }}"></time>
-  {% if event.type == 'shared_message' %}
-    {{ user_avatar(event.user) }}
-    <div class="e-feed-message">
-      <p>{{ gettext('%(user)s shared:', user=user_link(event.user)) }}</p>
-      <p>{{ event.message }}</p>
-      {% if current_user.is_authenticated() %}
-      <div class="e-actions">
-        {% call render_user_mailto_link(event.user) %}<span class="material-icons">reply</span> <span class="e-action-label">{{ gettext("Reply via e-mail") }}</span>{% endcall %}
-      </div>
-      {% endif %}
-    </div>
-  {% elif event.type == 'user_joined_event' %}
-    {{ user_avatar(event.user) }}
-    <div class="e-feed-message">
-      <p>{{ gettext('%(user)s joined NOI.', user=user_link(event.user)) }}</p>
-    </div>
-  {% elif event.type == 'connection_event' %}
-    <div class="e-feed-message">
-      <p>{{ ngettext('+%(num)d new connection made in NOI.', '+%(num)d new connections made in NOI.', event.emails.count()) }}</p>
-      <p>{{ gettext('%(total)s connections!', total=event.total_connections) }}</p>
-    </div>
-  {% else %}
-    <div class="e-feed-message">
-      UNKNOWN EVENT TYPE: {{ event.type }}
-    </div>
-  {% endif %}
-  </li>
-{% endfor %}
-  </ul>
+  {% include "_activity_events.html" %}
 {% endcall %}
 
 {% call render_tab_panel('connected', active_tab, class='b-activity-feed') %}
@@ -141,4 +102,18 @@
 </div>
 {% endif %}
 
+{% endblock %}
+
+{% block page_script %}
+<script src="{{ url_for('static', filename='vendor/jquery.jscroll.js') }}"></script>
+<script>
+$(function() {
+  $('#activity').jscroll({
+    loadingHtml: '<div class="e-load-more">' +
+                 {{ gettext("Loading...")|tojson }} +
+                 '</div>',
+    autoTrigger: false
+  });
+});
+</script>
 {% endblock %}

--- a/app/tests/test_views.py
+++ b/app/tests/test_views.py
@@ -265,6 +265,21 @@ class ActivityFeedTests(ViewTestCase):
         self.login()
         self.assert200(self.client.get('/activity'))
 
+    def test_activity_page_with_negative_number_is_not_found(self):
+        self.assert404(self.client.get('/activity/page/-1'))
+
+    def test_activity_page_zero_is_not_found(self):
+        self.assert404(self.client.get('/activity/page/0'))
+
+    def test_activity_page_one_is_ok(self):
+        self.assert200(self.client.get('/activity/page/1'))
+
+    def test_activity_page_with_non_number_is_not_found(self):
+        self.assert404(self.client.get('/activity/page/foo'))
+
+    def test_activity_page_with_too_big_a_number_is_not_found(self):
+        self.assert404(self.client.get('/activity/page/9999999'))
+
 class MyProfileTests(ViewTestCase):
     def test_get_requires_full_registration(self):
         self.login(fully_register=False)

--- a/app/views.py
+++ b/app/views.py
@@ -487,14 +487,33 @@ def match():
 
     return redirect(url_for('views.match_practitioners'))
 
+def get_latest_events(pageid=1):
+    return Event.query_in_deployment().order_by(desc(Event.created_at)).\
+           paginate(pageid)
+
+@views.route('/activity/page/<pageid>')
+def activity_page(pageid):
+    '''
+    Individual page for activity stream (for infinite scrolling).
+    '''
+
+    try:
+        pageid = int(pageid)
+        if pageid <= 0:
+            raise ValueError()
+    except ValueError:
+        abort(404)
+
+    return render_template('_activity_events.html',
+                           events=get_latest_events(pageid))
+
 @views.route('/activity', methods=['GET', 'POST'])
 def activity():
     '''
     View for the activity feed of recent events.
     '''
 
-    events = Event.query_in_deployment().order_by(desc(Event.created_at)).\
-             limit(50).all()
+    events = get_latest_events()
     shared_message_form = SharedMessageForm()
 
     if request.method == 'POST':


### PR DESCRIPTION
This will fix #129.

Right now we're not using the auto-triggering feature of [jScroll](http://jscroll.com/) because the plugin doesn't work well in conjunction with our bootstrap tabs: specifically, if a tab other than the activity stream is active, jScroll will spam our server with ajax requests when the user scrolls to the bottom of the page.

So for now we just show a down-arrow that the user can click on to load more.