### PR TITLE
Display innovation area "intro text" when users first fill them out

### DIFF
--- a/app/data/questions.yaml
+++ b/app/data/questions.yaml
@@ -3,12 +3,7 @@
   icon: opendata.svg
   icon-color: "#E86B5F"
   description: >
-   <p>What makes open data a powerful tool for governing better is that the ability of people inside and 
-   outside of institutions to use the same data to create useful policies, tools, visualizations, maps, and apps. 
-   Open data can provide the raw material to convene informed conversations about what’s broken and the 
-   empirical foundation for developing solutions.</p>
-   <p><b>These twenty questions help you describe what you know and can share about open data and what you want to learn from others. 
-   Click on a link below to create an expertise profile.</b></p>
+   When institutions open their data for research, analysis and reuse, it can be a powerful tool for improvement. Open data can provide the raw material to convene informed conversations about what’s broken and the empirical foundation for developing solutions.
   topics:
 
     - topic: Open Data Policy
@@ -72,14 +67,7 @@
   icon: prizes.svg
   icon-color: "#44A9A2"
   description: >
-   <p>Governments — and other entities — are increasing seeking to solve big 
-   problems using new technologies and innovative approaches. One of the most 
-   common approaches involves prize-backed contests as well as challenges and 
-   grand challenges. These competitions offer a range of advantages for 
-   government agencies, especially in an era of tightening budgets.</p>
-   <p><b>These twenty questions help you describe what you know and can share about prize-backed challenges
-    and what you want to learn from others. 
-   Click on a link below to create an expertise profile.</b></p>
+   Prize-Backed Challenges offer an incentive to encourage, recognise and reward innovation. When successfully executed, prize-backed challenges and competitions can also drive the adoption of innovations across an institution.
   topics:
 
     - topic: Scoping the Problem
@@ -159,17 +147,7 @@
   id: citizenscience
   icon: citizenscience.svg
   description: >
-   <p>Citizen science projects – task-based initiatives in which citizens of any 
-   background can help contribute to scientific research – like Galaxy Zoo and 
-   Zooniverse are demonstrating the ability of lay and expert citizens alike to 
-   make small, useful contributions to aid large, complex undertakings. As governing 
-   institutions seek to do more with less, looking to the success of citizen science 
-   initiatives could provide a blueprint for engaging citizens to help accomplish difficult,
-   time-consuming objectives at little cost.</p>
-   <p><b>These forty four questions help you describe what you know and can share 
-   about open data and what you want to learn from others. 
-   Click on a link below to create an expertise profile.</b></p>
-
+   Citizen science refers to scientific or research tasks that are undertaken collaboratively by volunteer members of the general public, scientists or researchers. Citizen science can provide an innovative method to help do better research and accomplish difficult objectives more effectively and efficiently.
   topics:
     - topic: Tasks and Goals
       description: defining the goals of a citizen science initiative and the tasks to be completed in order to achieve them
@@ -302,7 +280,8 @@
   id: datascience
   icon: datascience.svg
   icon-color: "#FF8E00"
-  description: TODO
+  description: >
+   Data Science is an interdisciplinary field about processes and systems to extract knowledge or insights from large volumes of data.
   topics:
     - topic: Data Collection
       description: data collection
@@ -345,9 +324,7 @@
   icon: communityengagement.png
   icon-color: "#A3ABD1"
   description: >
-    <p>Institutions often work best when their stakeholders -- whether citizens, customers, parents, patients, or other members of a community -- are directly engaged in decision-making and service delivery. Engagement can build trust and increase the legitimacy of decision-making. It can also help institutions solve problems more effectively by developing solutions that are designed in consultation with their stakeholders. But knowing when and how to engage members of a community and under what conditions is hard. </p>
-    <p>Share what you know and what you would like to learn about how to formulate, implement and measure a community engagement strategy.</p>
-
+   Engagement can build trust and increase the legitimacy of decision-making. But knowing when and how to engage members of a community and under what conditions is hard.
   topics:
     - topic:  Identifying goals and participants
       description: What you can share about setting the stage for a community engagement program.
@@ -424,9 +401,7 @@
   icon: labdesign.svg
   icon-color: "#50E3C2"
   description: >
-   <p>Governments are seeking to become more experimental and evidence-based through the creation of internal innovation labs. The growing labs movement is helping to uncover what works in practice. For questionnaires about the community engagement and crowdsourcing methods used by many Labs, see those dedicated questionnaires. </p>
-   <p><b>Click on a link below to create an expertise profile.</b></p>
-
+   Governments are seeking to become more experimental and evidence-based through the creation of internal innovation labs. The growing labs movement is helping to uncover what works in practice.
   topics:
     - topic: Lab Creation and Vision
       description: What you can share about launching a government innovation lab.
@@ -492,16 +467,7 @@
   id: crowdsourcing
   icon: crowdsourcing.svg
   description: >
-   <p>Crowdsourcing uses communications technologies to enable institutions 
-   to leverage the wisdom of the crowd. With crowdsourcing, organizations can get
-   help, for example, with performing tasks, obtaining ideas and opinions, 
-   gathering data, soliciting funds, or administering programs. By enabling institutions
-   to get more distributed and diverse collaboration in ways never before possible, 
-   they can improve a project’s efficiency, legitimacy and diversity. </p>
-   <p><b>These questions help you describe what you know and can share about crowdsourcing
-   and what you want to learn from others. Click on a link below to create an expertise 
-   profile.</b></p>
-
+   Crowdsourcing uses communications technologies to enable institutions to leverage the wisdom of the crowd. By enabling institutions to get more distributed and diverse collaboration in ways never before possible, they can improve a project’s efficiency, legitimacy and diversity.
   topics:
     - topic: Determining the Crowd
       description: What can you share about identifying, enrolling, and developing a crowd
@@ -615,8 +581,7 @@
   icon: opendata.svg
   icon-color: "#E86B5F"
   description: >
-   <p>Randomized Control Trials (RCTs) — comparing the outcomes of an intervention with a particular group against another randomly selected group that does not receive the intervention — are a rigorous and inexpensive way to find what works. Increasingly, public institutions are testing the effectiveness of services, for example, by delivering it two different ways.</p>
-   <p><b>Share your expertise</b></p>
+   Randomized Control Trials (RCTs) — comparing the outcomes of an intervention with a particular group against another randomly selected group that does not receive the intervention — are a rigorous and inexpensive way to find what works. Increasingly, public institutions are testing the effectiveness of services, for example, by delivering it two different ways.
   topics:
 
     - topic: Setting Up an Evaluation

--- a/app/static/sass/_profile.scss
+++ b/app/static/sass/_profile.scss
@@ -120,6 +120,13 @@
         padding: 0 20px;   
     }
 
+    .m-start {
+        display: block;
+        width: auto;
+        margin: 0 20px;
+        color: white;
+        background-color: $blue;
+    }
 }
 
 .b-public-profile {

--- a/app/templates/_profile-questionnaire.html
+++ b/app/templates/_profile-questionnaire.html
@@ -1,11 +1,28 @@
 <section class="b-profile-progress">
 <ul class="e-progress-container">
-  {% set questionnaire = question.questionnaire %}
+  {% if question %}
+    {% set questionnaire = question.questionnaire %}
+  {% else %}
+    {% set questionnaire = QUESTIONNAIRES_BY_ID[areaid] %}
+  {% endif %}
   {% set questionnaire_url = url_for('views.my_expertise', _anchor='expertise') %}
   {% set always_show_questions_left = true %}
   {% include "_profile-progress-item.html" %}
 </ul>
 </section>
+
+{% if next_url %}
+<section class="b-profile-questionnaire">
+    <div class="e-questions-container">
+        <div class="e-question">
+          <p class="e-question-text">
+            <em>{{ gettext(QUESTIONNAIRES_BY_ID[areaid].description) }}</em>
+          </p>
+        </div>
+        <a href="{{ next_url }}#expertise" class="b-button m-start">{{ gettext('Next') }}</a>
+    </div>
+</section>
+{% else %}
 
 {# TODO: A fair amount of this is copied/pasted from
  # register-step-3.html, consider refactoring. #}
@@ -39,3 +56,4 @@
         </div>
     </div>
 </section>
+{% endif %}

--- a/app/templates/about.html
+++ b/app/templates/about.html
@@ -32,35 +32,35 @@
             <ul>
               <li>
                 <p class="e-question">Open Data</p>
-                <p class="e-answer">When institutions open their data for research, analysis and reuse, it can be a powerful tool for improvement. Open data can provide the raw material to convene informed conversations about what’s broken and the empirical foundation for developing solutions.</p>
+                <p class="e-answer">{{ gettext(QUESTIONNAIRES_BY_ID.opendata.description) }}</p>
               </li>
               <li>
                 <p class="e-question">Data Science</p>
-                <p class="e-answer">Data Science is an interdisciplinary field about processes and systems to extract knowledge or insights from large volumes of data.</p>
+                <p class="e-answer">{{ gettext(QUESTIONNAIRES_BY_ID.datascience.description) }}</p>
               </li>
               <li>
                 <p class="e-question">Community Engagement</p>
-                <p class="e-answer">Engagement can build trust and increase the legitimacy of decision-making. But knowing when and how to engage members of a community and under what conditions is hard.</p>
+                <p class="e-answer">{{ gettext(QUESTIONNAIRES_BY_ID.communityengagement.description) }}</p>
               </li>
               <li>
                 <p class="e-question">Citizen Science</p>
-                <p class="e-answer">Citizen science refers to scientific or research tasks that are undertaken collaboratively by volunteer members of the general public, scientists or researchers. Citizen science can provide an innovative method to help do better research and accomplish difficult objectives more effectively and efficiently.</p>
+                <p class="e-answer">{{ gettext(QUESTIONNAIRES_BY_ID.citizenscience.description) }}</p>
               </li>
               <li>
                 <p class="e-question">Crowdsourcing</p>
-                <p class="e-answer">Crowdsourcing uses communications technologies to enable institutions to leverage the wisdom of the crowd. By enabling institutions to get more distributed and diverse collaboration in ways never before possible, they can improve a project’s efficiency, legitimacy and diversity.</p>
+                <p class="e-answer">{{ gettext(QUESTIONNAIRES_BY_ID.crowdsourcing.description) }}</p>
               </li>
               <li>
                 <p class="e-question">Randomized Control Trials</p>
-                <p class="e-answer">Randomized Control Trials (RCTs) — comparing the outcomes of an intervention with a particular group against another randomly selected group that does not receive the intervention — are a rigorous and inexpensive way to find what works. Increasingly, public institutions are testing the effectiveness of services, for example, by delivering it two different ways.</p>
+                <p class="e-answer">{{ gettext(QUESTIONNAIRES_BY_ID.rcts.description) }}</p>
               </li>
               <li>
                 <p class="e-question">Prize-Backed Challenges</p>
-                <p class="e-answer">Prize-Backed Challenges offer an incentive to encourage, recognise and reward innovation. When successfully executed, prize-backed challenges and competitions can also drive the adoption of innovations across an institution.</p>
+                <p class="e-answer">{{ gettext(QUESTIONNAIRES_BY_ID.prizes.description) }}</p>
               </li>
               <li>
                 <p class="e-question">Lab Design</p>
-                <p class="e-answer">Governments are seeking to become more experimental and evidence-based through the creation of internal innovation labs. The growing labs movement is helping to uncover what works in practice.</p>
+                <p class="e-answer">{{ gettext(QUESTIONNAIRES_BY_ID['lab-design'].description) }}</p>
               </li>
             </ul>
         </li>

--- a/app/templates/register-step-3.html
+++ b/app/templates/register-step-3.html
@@ -44,7 +44,9 @@
 
 <div class="b-onboarding-questions">
     <div class="e-card m-intro">
-      <p class="e-text">{{ gettext("Now answer %(num)s questions about your experience in this area to join the network and get matched with other innovators!", num=questions_left) }}</p>
+      <h3 class="e-card-category">{{ gettext(QUESTIONNAIRES_BY_ID[areaid].name) }}</h3>
+      <p class="e-text"><em>{{ gettext(QUESTIONNAIRES_BY_ID[areaid].description) }}</em></p>
+      <p class="e-text">{{ gettext("Now answer %(num)s questions about your experience in this area to join the network and get matched with other innovators!", num=MIN_QUESTIONS_TO_JOIN) }}</p>
       <p class="e-aux-text">{{ gettext("You can always answer more questions by going to your profile page to get new and more relevant matches.") }}</p>
       <a href="{{ next_url }}" class="b-button">{{ gettext('Next') }}</a>
     </div>

--- a/app/templates/user-profile.html
+++ b/app/templates/user-profile.html
@@ -107,7 +107,7 @@ b-public-profile
 
 {% if is_current_user_profile %}
 
-{% if question %}
+{% if in_questionnaire %}
   {% call render_tab_panel('expertise', active_tab) %}
   {% include "_profile-questionnaire.html" %}
   {% endcall %}
@@ -190,7 +190,7 @@ b-public-profile
         $('a[href="#overview"]').one('shown.bs.tab', renderChart);
       }
 </script>
-{% if is_current_user_profile and active_tab == 'expertise' and question %}
+{% if in_questionnaire %}
 <script>
 $(function() {
   if (window.location.hash == '') {

--- a/app/tests/test_views.py
+++ b/app/tests/test_views.py
@@ -150,18 +150,9 @@ class MultiStepRegistrationTests(ViewTestCase):
         self.assertContext('user_can_join', False)
 
     def test_step_3_with_areaid_links_to_first_unanswered_question(self):
-        # When the user hasn't answered ANY questions yet, we present
-        # them with instructions instead of redirecting them.
         res = self.client.get('/register/step/3/opendata')
         self.assert200(res)
         assert '/register/step/3/opendata/1' in res.data
-
-    def test_step_3_with_areaid_redirects_to_first_unanswered_question(self):
-        self.client.post('/register/step/3/opendata/1', data={
-            'answer': '-1'
-        })
-        self.assertRedirects(self.client.get('/register/step/3/opendata'),
-                             '/register/step/3/opendata/2')
 
     def test_step_3_with_questionid_is_ok(self):
         self.assert200(self.client.get('/register/step/3/opendata/1'))

--- a/app/tests/test_views.py
+++ b/app/tests/test_views.py
@@ -317,10 +317,12 @@ class MyExpertiseTests(ViewTestCase):
     def test_get_is_ok(self):
         self.assert200(self.client.get('/my-expertise/'))
 
-    def test_with_areaid_redirects_to_first_unanswered_question(self):
-        self.assertRedirects(self.client.get('/my-expertise/opendata'),
-                             '/my-expertise/opendata/1')
+    def test_with_areaid_and_no_skills_shows_into_text(self):
+        res = self.client.get('/my-expertise/opendata')
+        self.assert200(res)
+        assert '/my-expertise/opendata/1#expertise' in res.data
 
+    def test_with_areaid_and_skills_redirects_to_unanswered_question(self):
         self.client.post('/my-expertise/opendata/1', data={
             'answer': '-1'
         })

--- a/app/views.py
+++ b/app/views.py
@@ -176,12 +176,12 @@ def register_step_3_area(areaid):
         if question['id'] not in skills:
             break
 
-    next_url = url_for('views.register_step_3_area_question',
-                       areaid=areaid, questionid=str(i+1))
-
-    if len(current_user.skills) == 0 or request.args.get('no_redirect'):
-        return render_register_step_3(next_url=next_url)
-    return redirect(next_url)
+    return render_register_step_3(
+        next_url=url_for('views.register_step_3_area_question',
+                         areaid=areaid, questionid=str(i+1)),
+        areaid=areaid,
+        MIN_QUESTIONS_TO_JOIN=MIN_QUESTIONS_TO_JOIN
+    )
 
 @views.route('/register/step/3/<areaid>/<questionid>',
              methods=['GET', 'POST'])


### PR DESCRIPTION
This fixes #181.

During onboarding, this changes the onboarding innovation area intro text so it includes the area description:

<img width="541" alt="screen shot 2015-10-25 at 12 20 32 pm" src="https://cloud.githubusercontent.com/assets/124687/10716544/f484f7a6-7b12-11e5-86d2-5efedf36c282.png">

Similarly, when users have started a questionnaire via their profile in an area that they don't have any reported skills in, they are shown the intro text:

![2015-10-25_15-58-24](https://cloud.githubusercontent.com/assets/124687/10717542/00ea4aae-7b32-11e5-8e5c-ee0d3c80c195.png)

However, this interstitial is skipped if the user has already answered any questions in the area.
