### PR TITLE
Set max-width of desktop to 1080px

### DIFF
--- a/app/static/sass/_desktop-hack.scss
+++ b/app/static/sass/_desktop-hack.scss
@@ -1,6 +1,6 @@
 body {
     @include breakpoint($desktop) {
-        max-width: 500px;
+        max-width: $desktop;
         margin: 0 auto;
         background-color: $white;
         min-height: 100vh;   


### PR DESCRIPTION
This is just a suggestion--basically it sets the max desktop width to 1080px (which is also the desktop "breakpoint" at which this max-width rule is enabled) instead of the 500px it's currently set to.

Reasons for this change:
* I think it's a bit weird to have the width of the actual content become *smaller* as one widens the window, which is currently what happens: if one wants their content to be as wide as possible, they're best off setting the width of their browser window to 1079px instead of anything greater!
* Scrolling on the tab nav is especially painful to use on desktop, or any device on which users can't easily scroll horizontally (such as a mouse with a vertical-only scroll wheel):

  ![2015-10-26_18-28-48](https://cloud.githubusercontent.com/assets/124687/10744320/6ca20b28-7c0f-11e5-8a32-657e858cea79.png)

  The screenshot above is taken with max-width set to 500px, which means that in order to see more tabs, a desktop user with a mousewheel actually needs to use the scrollbar, which is terrible due to [Fitts's Law](https://en.wikipedia.org/wiki/Fitts's_law). Setting the max-width to 1080px, on the other hand, makes all tabs on the site visible without requiring scrolling, thereby making this a much less stressful experience for desktop users.