### PR TITLE
Improve search functionality

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -2,7 +2,7 @@
 NoI forms
 '''
 
-from app import LOCALES, l10n
+from app import LOCALES, QUESTIONNAIRES, l10n
 from app.models import User
 
 from flask import current_app
@@ -33,6 +33,18 @@ import re
 #from app.models import db
 
 ModelForm = model_form_factory(Form)
+
+
+class CallableChoicesSelectField(SelectField):
+    '''
+    Subclass of SelectField that can take a callable for `choices`.
+
+    The function is only executed at instantiatino.
+    '''
+    def __init__(self, *args, **kwargs):
+        if 'choices' in kwargs and hasattr(kwargs['choices'], '__call__'):
+            kwargs['choices'] = kwargs['choices']()
+        super(CallableChoicesSelectField, self).__init__(*args, **kwargs)
 
 
 class CallableChoicesSelectMultipleField(SelectMultipleField):
@@ -145,6 +157,16 @@ class SearchForm(Form):
     '''
     Form for searching the user database.
     '''
+
+    questionnaire_area = CallableChoicesSelectField(
+        choices=lambda: [
+            ('ZZ', lazy_gettext('Choose an expertise area'))
+        ] + [
+            (q['id'], lazy_gettext(q['name']))
+            for q in QUESTIONNAIRES
+            if q['questions']
+        ]
+    )
     country = CountryField()
     locales = CallableChoicesSelectMultipleField(
         widget=Select(multiple=True),

--- a/app/forms.py
+++ b/app/forms.py
@@ -2,7 +2,7 @@
 NoI forms
 '''
 
-from app import LOCALES, QUESTIONNAIRES, l10n
+from app import LOCALES, QUESTIONNAIRES, LEVELS, l10n
 from app.models import User
 
 from flask import current_app
@@ -176,6 +176,13 @@ class SearchForm(Form):
         widget=Select(multiple=True),
         choices=lambda: [(v, lazy_gettext(v)) for v in current_app.config['DOMAINS']])
 
+    # This doesn't actually appear as a field in a form, but as a tab
+    # in a result set, so it's a bit unusual.
+    skill_level = SelectField(
+        choices=[(level['score'], '') for level in LEVELS.values()],
+        coerce=int,
+        default=LEVELS['LEVEL_I_CAN_DO_IT']['score']
+    )
 
 class ChangeLocaleForm(Form):
     '''

--- a/app/templates/search.html
+++ b/app/templates/search.html
@@ -22,6 +22,10 @@
 {% block content %}
 <section class="b-filters">
   <form action="{{ url_for('views.search') }}" method="GET">
+    <label for="questionnaire_area">{{ gettext('By expertise area') }}</label>
+    <div class="b-dropdown">
+      {{ form.questionnaire_area() }}
+    </div>
     <label for="country">{{ gettext('By country') }}</label>
     <div class="b-dropdown">
       {{ form.country() }}
@@ -45,6 +49,7 @@
   <div class="e-results-container">
     {% for user, score in results %}
     {% if user.display_in_search %}
+      <!-- Score: {{ score }} -->
       <a class="e-result-item" href="{{ url_for('views.get_user', userid=user.id) }}">
         <img src="{{ get_user_avatar_url(user) }}" alt="" class="e-picture">
         <p class="e-name">{{ user.full_name }}</p>

--- a/app/templates/search.html
+++ b/app/templates/search.html
@@ -17,10 +17,11 @@
   </style>
 {% endblock %}
 
-{% from "_macros.html" import get_user_avatar_url, render_multi_select_instructions %}
+{% from "_macros.html" import get_user_avatar_url, render_multi_select_instructions, render_static_tab_bar, render_static_tab_panel %}
 
 {% block content %}
 <section class="b-filters">
+  {{ base_tabbed_results_url }}
   <form action="{{ url_for('views.search') }}" method="GET">
     <label for="questionnaire_area">{{ gettext('By expertise area') }}</label>
     <div class="b-dropdown">
@@ -45,7 +46,13 @@
 </section>
 
 {% if results %}
+<div id="results">
+{% if result_tabs %}
+  {{ render_static_tab_bar(result_tabs, active_result_tab) }}
+{% endif %}
 <section class="b-innovator-results">
+
+{% macro show_results() %}
   <div class="e-results-container">
     {% for user, score in results %}
     {% if user.display_in_search %}
@@ -58,7 +65,18 @@
     {% endif %}
     {% endfor %}
   </div>
+{% endmacro %}
+
+{% if result_tabs %}
+  {% call render_static_tab_panel() %}
+    {{ show_results() }}
+  {% endcall %}
+{% else %}
+  {{ show_results() }}
+{% endif %}
+
 </section>
+</div>
 {% endif %}
 
 {% endblock %}

--- a/app/tests/test_views.py
+++ b/app/tests/test_views.py
@@ -541,7 +541,7 @@ class ViewTests(ViewTestCase):
 
     def test_search_results_is_ok(self):
         self.login()
-        res = self.client.get('/search?country=ZZ')
+        res = self.client.get('/search?country=ZZ&questionnaire_area=ZZ')
         self.assert200(res)
         assert "e-results-container" in res.data
 

--- a/app/views.py
+++ b/app/views.py
@@ -22,6 +22,7 @@ from sqlalchemy.dialects.postgres import array
 
 from boto.s3.connection import S3Connection
 
+from urllib import urlencode
 import mimetypes
 import functools
 import json
@@ -502,6 +503,8 @@ def search():
     if not form.validate():
         return render_template('search.html', form=form)
     else:
+        result_tabs = []
+        active_result_tab = None
         query = User.query_in_deployment() #pylint: disable=no-member
 
         if (form.questionnaire_area.data and
@@ -511,8 +514,31 @@ def search():
             query = query.add_column(num_skills_column).\
                 filter(UserSkill.user_id == User.id).\
                 filter(UserSkill.name.like(questionnaire_id + "_%")).\
+                filter(UserSkill.level == form.skill_level.data).\
                 group_by(User).\
                 order_by(num_skills_column.desc())
+
+            base_args = request.args.copy()
+            if 'skill_level' in base_args:
+                del base_args['skill_level']
+
+            tab_names = (
+                ('LEVEL_I_CAN_DO_IT', gettext('Practitioners')),
+                ('LEVEL_I_CAN_EXPLAIN', gettext('Explainers')),
+                ('LEVEL_I_CAN_REFER', gettext('Connectors')),
+                ('LEVEL_I_WANT_TO_LEARN', gettext('Peers')),
+            )
+
+            for level_id, tab_label in tab_names:
+                tab_args = base_args.copy()
+                tab_args['skill_level'] = str(LEVELS[level_id]['score'])
+                tab_url = '%s?%s#results' % (
+                    url_for('views.search'),
+                    urlencode(tab_args)
+                )
+                if form.skill_level.data == LEVELS[level_id]['score']:
+                    active_result_tab = level_id
+                result_tabs.append((level_id, tab_label, tab_url))
         else:
             # Add fake rank of 0 for now
             query = query.add_column('0')
@@ -529,6 +555,8 @@ def search():
                 form.expertise_domain_names.data))
 
         return render_template('search.html',
+                               result_tabs=result_tabs,
+                               active_result_tab=active_result_tab,
                                form=form,
                                results=query.limit(20).all())
 


### PR DESCRIPTION
- [x] Add a "by expertise area" field to the search form.
- [x] Add practitioners/connectors/peers/explainers tabs to the search results.
- [x] Add tests or file a tech debt bug for adding them later.

I *think* that's all that's needed to make the search more useful for now. It won't resolve all of #232, but AFAIK it's the smallest scope of work for a single PR that will still result in a coherent end-user experience.