### PR TITLE
Add admin panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,20 @@ following in `noi/app/config/local_config.yml`:
     SERVER_NAME:
     GA_TRACKING_CODE:
     SECRET_KEY:
+
+    # A list of email addresses to send error reports to.
     ADMINS:
       - admin@example.org
+      - error_reports@example.org
+
+    # A list of email addresses corresponding to users who will be
+    # able to access the admin panel.
+    ADMIN_UI_USERS:
+      - admin@example.org
+
+    # A string of the form username:password that will add an extra layer
+    # of HTTP Basic Authentication to the admin UI.
+    ADMIN_UI_BASIC_AUTH: stay_away:uninvited_guests
 
 If you want SSL to work, you'll need to uncomment the lines in
 `/conf/ssl/ssl.conf`, and add the secret key and certificate of the same name

--- a/app/admin.py
+++ b/app/admin.py
@@ -10,14 +10,15 @@ from .models import User, db
 
 class NoiModelView(ModelView):
     # The latest docs for flask-admin document a SecureForm class, but
-    # this hasn't yet been added to the latest release, so we'll use
-    # the "old" way of enabling CSRF support, documented here:
+    # it doesn't seem to work, so we'll use the "old" way of enabling
+    # CSRF support, documented here:
     #
     # http://flask-admin.readthedocs.org/en/v1.3.0/introduction/
     form_base_class = flask_wtf.Form
 
     can_delete = False
     can_create = False
+    can_export = True
 
     def is_accessible(self):
         return current_user.is_authenticated() and current_user.is_admin()

--- a/app/admin.py
+++ b/app/admin.py
@@ -1,0 +1,41 @@
+from flask import redirect, request
+from flask_login import current_user
+from flask_security.utils import url_for_security
+from flask_admin import Admin
+from flask_admin.contrib.sqla import ModelView
+import flask_wtf
+from wtforms import TextField
+
+from .models import User, db
+
+class NoiModelView(ModelView):
+    # The latest docs for flask-admin document a SecureForm class, but
+    # this hasn't yet been added to the latest release, so we'll use
+    # the "old" way of enabling CSRF support, documented here:
+    #
+    # http://flask-admin.readthedocs.org/en/v1.3.0/introduction/
+    form_base_class = flask_wtf.Form
+
+    can_delete = False
+    can_create = False
+
+    def is_accessible(self):
+        return current_user.is_authenticated() and current_user.is_admin()
+
+    def inaccessible_callback(self, name, **kwargs):
+        return redirect(url_for_security('login', next=request.url))
+
+
+class UserModelView(NoiModelView):
+    column_list = ('first_name', 'last_name', 'email')
+    form_columns = column_list
+    column_searchable_list = ('first_name', 'last_name', 'email')
+
+    def scaffold_form(self):
+        form_class = super(UserModelView, self).scaffold_form()
+        form_class.email = TextField('Email')
+        return form_class
+
+def init_app(app):
+    admin = Admin(app, template_mode='bootstrap3')
+    admin.add_view(UserModelView(User, db.session))

--- a/app/admin.py
+++ b/app/admin.py
@@ -28,8 +28,10 @@ class NoiModelView(ModelView):
 
 
 class UserModelView(NoiModelView):
-    column_list = ('first_name', 'last_name', 'email')
-    form_columns = column_list
+    column_list = ('first_name', 'last_name', 'email', 'last_login_at',
+                   'login_count')
+    form_columns = ('first_name', 'last_name', 'email', 'position',
+                    'organization', 'city', 'projects')
     column_searchable_list = ('first_name', 'last_name', 'email')
 
     def scaffold_form(self):

--- a/app/admin.py
+++ b/app/admin.py
@@ -46,7 +46,10 @@ class UserModelView(NoiModelView):
 
     def scaffold_form(self):
         form_class = super(UserModelView, self).scaffold_form()
+
+        # https://github.com/flask-admin/flask-admin/issues/1134
         form_class.email = TextField('Email')
+
         return form_class
 
 

--- a/app/admin.py
+++ b/app/admin.py
@@ -1,12 +1,22 @@
+import json
+
 from flask import redirect, request
 from flask_login import current_user
 from flask_security.utils import url_for_security
-from flask_admin import Admin
+from flask_admin import Admin, BaseView, expose
 from flask_admin.contrib.sqla import ModelView
 import flask_wtf
 from wtforms import TextField
 
 from .models import User, db
+from . import stats
+
+class StatsView(BaseView):
+    @expose('/')
+    def index(self):
+        return self.render('admin/stats_index.html',
+                           stats=json.dumps(stats.generate(), indent=2))
+
 
 class NoiModelView(ModelView):
     # The latest docs for flask-admin document a SecureForm class, but
@@ -39,6 +49,8 @@ class UserModelView(NoiModelView):
         form_class.email = TextField('Email')
         return form_class
 
+
 def init_app(app):
-    admin = Admin(app, template_mode='bootstrap3')
+    admin = Admin(app, name='NoI Admin', template_mode='bootstrap3')
     admin.add_view(UserModelView(User, db.session))
+    admin.add_view(StatsView(name='Stats', endpoint='stats'))

--- a/app/csp.py
+++ b/app/csp.py
@@ -14,6 +14,8 @@ def add_header(response):
         # Ugh, flask-admin has inline scripts. Since only a handful of
         # users will have access to this view anyways, just disable CSP
         # for it.
+        #
+        # https://github.com/flask-admin/flask-admin/issues/1135
         return response
 
     script_src = [

--- a/app/csp.py
+++ b/app/csp.py
@@ -1,5 +1,5 @@
 from app import csrf
-from flask import current_app, make_response, request, Response
+from flask import current_app, make_response, request, Response, url_for
 
 from hashlib import sha256
 from base64 import b64encode
@@ -9,6 +9,12 @@ def add_header(response):
     '''
     Add a Content Security Policy (CSP) header to the given response.
     '''
+
+    if request.path.startswith(url_for('admin.index')):
+        # Ugh, flask-admin has inline scripts. Since only a handful of
+        # users will have access to this view anyways, just disable CSP
+        # for it.
+        return response
 
     script_src = [
         "'self'",

--- a/app/factory.py
+++ b/app/factory.py
@@ -10,7 +10,7 @@ from flask.ext.babel import get_locale
 from flask_security import SQLAlchemyUserDatastore, user_registered
 from flask_security.utils import get_identity_attributes
 
-from app import (csrf, cache, mail, bcrypt, s3, assets, security,
+from app import (csrf, cache, mail, bcrypt, s3, assets, security, admin,
                  babel, celery, alchemydumps, sass, email_errors, csp,
                  QUESTIONNAIRES, NOI_COLORS, LEVELS, ORG_TYPES,
                  QUESTIONS_BY_ID, LEVELS_BY_SCORE, QUESTIONNAIRES_BY_ID)
@@ -134,6 +134,7 @@ def create_app(config=None): #pylint: disable=too-many-statements
     app.config['SEARCH_DEPLOYMENTS'].append(noi_deploy)
     babel.init_app(app)
     l10n.init_app(app)
+    admin.init_app(app)
 
     app.config['DOMAINS'] = this_deployment.get('domains',
                                                 default_deployment['domains'])

--- a/app/models.py
+++ b/app/models.py
@@ -157,6 +157,9 @@ class User(db.Model, UserMixin, DeploymentMixin): #pylint: disable=no-init,too-f
     updated_at = Column(types.DateTime(), default=datetime.datetime.now,
                         onupdate=datetime.datetime.now)
 
+    def is_admin(self):
+        return self.email in current_app.config.get('ADMIN_UI_USERS', [])
+
     @property
     def full_name(self):
         return u"%s %s" % (self.first_name, self.last_name)

--- a/app/templates/__base_ui__.html
+++ b/app/templates/__base_ui__.html
@@ -79,6 +79,9 @@
         <a href="{{ url_for('views.faq') }}">{{ gettext('FAQ') }}</a>
         <a href="{{ url_for('views.about_page') }}">{{ gettext('About') }}</a>
         <a href="{{ url_for('views.terms_and_conditions') }}">{{ gettext("Terms of Service") }}</a>
+        {% if current_user.is_admin() -%}
+        <a href="{{ url_for('admin.index') }}">{{ gettext('Admin Panel') }}</a>
+        {%- endif %}
         <a href="{{ url_for_security('logout') }}">{{ gettext('Sign Out') }}</a>
     </section>
 

--- a/app/templates/admin/index.html
+++ b/app/templates/admin/index.html
@@ -1,0 +1,9 @@
+{% extends 'admin/master.html' %}
+
+{% block body %}
+  {% if current_user.is_authenticated() and current_user.is_admin() %}
+    <p>Welcome to the NoI admin panel.</p>
+  {% else %}
+    <p>You probably shouldn't be here.</p>
+  {% endif %}
+{% endblock %}

--- a/app/templates/admin/master.html
+++ b/app/templates/admin/master.html
@@ -1,0 +1,5 @@
+{% extends admin_base_template %}
+
+{% block brand %}
+  <a class="navbar-brand" href="{{ url_for('views.activity') }}">{{ gettext("Network of Innovators") }}</a>
+{% endblock %}

--- a/app/templates/admin/stats_index.html
+++ b/app/templates/admin/stats_index.html
@@ -1,0 +1,6 @@
+{% extends "admin/master.html" %}
+
+{% block body %}
+<p>Here are some statistics about NoI. Sorry they aren't documented yet!</p>
+<pre>{{ stats }}</pre>
+{% endblock %}

--- a/app/tests/test_admin.py
+++ b/app/tests/test_admin.py
@@ -1,0 +1,83 @@
+from base64 import b64encode
+
+from flask import Flask
+from flask_testing import TestCase
+
+from .test_views import ViewTestCase
+from ..admin import _init_basic_auth as init_basic_auth
+
+class AdminTestCase(ViewTestCase):
+    BASE_APP_CONFIG = ViewTestCase.BASE_APP_CONFIG.copy()
+
+    BASE_APP_CONFIG['ADMIN_UI_USERS'] = ['admin@example.org']
+
+    def setUp(self):
+        super(AdminTestCase, self).setUp()
+        self.admin_user = self.create_user(u'admin@example.org', 'password')
+        self.normal_user = self.create_user(u'normal@example.org', 'password')
+
+
+class UserModelViewTests(AdminTestCase):
+    def test_anonymous_users_are_redirected_to_login(self):
+        self.assertRedirects(self.client.get('/admin/user/'),
+                             '/login?next=%2Fadmin%2Fuser%2F')
+
+    def test_non_admin_users_receive_403(self):
+        self.login('normal@example.org', 'password')
+        self.assert403(self.client.get('/admin/user/'))
+
+    def test_admin_users_are_not_redirected_to_login(self):
+        self.login('admin@example.org', 'password')
+        self.assert200(self.client.get('/admin/user/'))
+
+
+class StatsViewTests(AdminTestCase):
+    def test_anonymous_users_are_redirected_to_login(self):
+        self.assertRedirects(self.client.get('/admin/stats/'),
+                             '/login?next=%2Fadmin%2Fstats%2F')
+
+    def test_non_admin_users_receive_403(self):
+        self.login('normal@example.org', 'password')
+        self.assert403(self.client.get('/admin/stats/'))
+
+    def test_admin_users_are_not_redirected_to_login(self):
+        self.login('admin@example.org', 'password')
+        self.assert200(self.client.get('/admin/stats/'))
+
+
+class BasicAuthTests(TestCase):
+    def create_app(self):
+        app = Flask('test')
+        app.config.update({'ADMIN_UI_BASIC_AUTH': 'foo:bar'})
+
+        @app.route('/foo/bar')
+        def non_admin_path():
+            return "I am a non-admin path!"
+
+        @app.route('/admin/blarg')
+        def admin_path():
+            return "I am an admin path!"
+
+        init_basic_auth(app)
+        return app
+
+    def test_non_admin_paths_are_accessible(self):
+        self.assert200(self.client.get('/foo/bar'))
+
+    def test_admin_paths_receive_401(self):
+        res = self.client.get('/admin/blarg')
+        self.assert401(res)
+        self.assertEqual(res.headers['WWW-Authenticate'],
+                         'Basic realm="NoI Admin"')
+
+    def test_admin_paths_with_invalid_userpass_receive_401(self):
+        res = self.client.get('/admin/blarg', headers={
+            'Authorization': 'Basic %s' % b64encode('foo:NOT BAR')
+        })
+        self.assert401(res)
+
+    def test_admin_paths_with_valid_userpass_are_accessible(self):
+        res = self.client.get('/admin/blarg', headers={
+            'Authorization': 'Basic %s' % b64encode('foo:bar')
+        })
+        self.assert200(res)


### PR DESCRIPTION
This PR adds an "Admin Panel" link to the user menu for qualified super-users:

![user_menu](https://cloud.githubusercontent.com/assets/124687/11732428/13d5d7a0-9f72-11e5-81db-2e8230f94a37.png)

Clicking on it takes the administrator to a page where they can list/edit users and export them to CSV:

![user_list](https://cloud.githubusercontent.com/assets/124687/11732439/35bc0970-9f72-11e5-975c-65862dd64acf.png)

It also provides functionality to get some (currently undocumented) statistics:

![stats](https://cloud.githubusercontent.com/assets/124687/11732451/44fb8564-9f72-11e5-8710-bb9a4d9c699d.png)

## Implementation Notes

We use [flask-admin](http://flask-admin.readthedocs.org/) for this.

We also need a way of tracking which users are admins and which aren't. For now we'll just use the `ADMIN_UI_USERS` config list for this, where each entry is the email of an admin user.

This PR also adds a `is_admin()` method to the `User` model which essentially returns whether the user's email is in `ADMIN_UI_USERS`.

Note that since we don't actually support email validation at present, admins will have to manually verify that the users associated with the emails in `ADMIN_UI_USERS` are actually who they claim to be.

To further prevent against malicious attempts to poke at these endpoints, `ADMIN_UI_BASIC_AUTH` can optionally be set to a string of the form *username:password* and HTTP Basic Authentication will protect everything under `/admin/`.