### PR TITLE
Add a lightweight docker container that inherits from the elephantine Docker Hub one

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,6 @@ you're using a pip library wrong.
 If you have a global `pylint` installed, you should remove it as it won't be
 able to track dependencies properly.
 
-Then, you need to pull the images.  This will take a minute the first time.
-If requirements change, you need to do this again.
-
-    docker-compose pull
-
 Then you need to build necessary images with:
 
     docker-compose build

--- a/README.md
+++ b/README.md
@@ -56,10 +56,14 @@ you're using a pip library wrong.
 If you have a global `pylint` installed, you should remove it as it won't be
 able to track dependencies properly.
 
-Then, you need to pul the images.  This will take a minute the first time.
+Then, you need to pull the images.  This will take a minute the first time.
 If requirements change, you need to do this again.
 
     docker-compose pull
+
+Then you need to build necessary images with:
+
+    docker-compose build
 
 You may also want to seed the database with a bunch of random users and
 other data, which can be done via:

--- a/README.md
+++ b/README.md
@@ -136,23 +136,47 @@ Tests are located in `app/tests`. Please feel free to add more!
 
 ### Changing the Dockerfile
 
-The primary container for the app is hosted on [Docker Hub][].
+This app uses *two* different Dockerfiles:
+
+* `app/Dockerfile` is the "base" container for the app; it's hosted on
+  [Docker Hub][] and retrieved from there. It's fairly large, takes a long
+  time to build; it's also versioned and shouldn't change very often.
+* `app/docker-quick/Dockerfile` sits atop the base container and is
+  built on development/production infrastructure. It shouldn't take
+  long to build, and its contents should regularly be moved over to
+  `app/Dockerfile` and tagged as a new version on Docker Hub.
 
 This is done to make it fast to get new deploys and Travis CI builds
-up and running. However, when you need to change the container, you
-won't want to pull the image from Docker Hub; instead, you'll want to:
+up and running, while also making it easy to experiment with new
+dependencies.
 
-  1. Edit `docker-compose.yml` and change the line
-     `image: thegovlab/noi2:latest` to be `build: app/`.
-  2. Make any changes you need to `app/Dockerfile`.
-  3. Run `docker-compose build`.
+#### Updating app/docker-quick/Dockerfile
+
+This Dockerfile is easy to update; just change the file or
+`requirements.quick.txt` as needed and re-run `docker-compose build` to
+rebuild the container.
 
 You may want to run `docker-compose run app bash` to poke into your
-newly-built container and make sure things work. Once you're satisfied,
-you'll want to commit the new Dockerfile and push the changes to
-GitHub; at this point, Docker Hub will build a new image for others
-to download. You can monitor the status of the build on Docker Hub's
-[Build Details][] page.
+newly-built container and make sure things work.
+
+#### Updating app/Dockerfile
+
+Updating this Dockerfile takes more work:
+
+1. Find the current version of the base dockerfile by looking at
+   the `FROM` directive of `app/docker-quick/Dockerfile`. The rest
+   of these instructions assume it is `docker-base-0.1` for the sake of
+   example.
+2. Move lines from `app/docker-quick/Dockerfile` and 
+   `requirements.quick.txt` over to `app/Dockerfile` and `requirements.txt`
+   as needed.
+3. Commit the changes and tag the revision with `git tag docker-base-0.2`.
+4. Push the changes to GovLab/noi2 on GitHub with
+   `git push git@github.com:GovLab/noi2.git docker-base-0.2`. This will
+   trigger a new build of the container on Docker Hub, which you can
+   monitor at Docker Hub's [Build Details][] page.
+5. Once Docker Hub is finished, update the `FROM` directive of
+   `app/docker-quick/Dockerfile` to point to `docker-base-0.2`.
 
 ### Editing CSS
 

--- a/app/docker-quick/Dockerfile
+++ b/app/docker-quick/Dockerfile
@@ -1,0 +1,13 @@
+#
+# Network of Innovators Dockerfile for web
+#
+# https://github.com/govlab/noi2
+#
+
+FROM thegovlab/noi2:latest
+MAINTAINER Atul Varma <atul@thegovlab.org>
+
+RUN apt-get install -y git
+
+COPY requirements.quick.txt /noi/app/
+RUN pip install --upgrade -r /noi/app/requirements.quick.txt

--- a/app/docker-quick/Dockerfile
+++ b/app/docker-quick/Dockerfile
@@ -4,7 +4,7 @@
 # https://github.com/govlab/noi2
 #
 
-FROM thegovlab/noi2:latest
+FROM thegovlab/noi2:docker-base-0.1
 MAINTAINER Atul Varma <atul@thegovlab.org>
 
 COPY requirements.quick.txt /noi/app/

--- a/app/docker-quick/Dockerfile
+++ b/app/docker-quick/Dockerfile
@@ -7,7 +7,5 @@
 FROM thegovlab/noi2:latest
 MAINTAINER Atul Varma <atul@thegovlab.org>
 
-RUN apt-get install -y git
-
 COPY requirements.quick.txt /noi/app/
 RUN pip install --upgrade -r /noi/app/requirements.quick.txt

--- a/app/docker-quick/requirements.quick.txt
+++ b/app/docker-quick/requirements.quick.txt
@@ -1,1 +1,1 @@
-git+git://github.com/flask-admin/flask-admin@47d965fbae473e0dd6755ef4a79f34c1d493d1a0#egg=Flask-Admin
+https://github.com/flask-admin/flask-admin/zipball/47d965fbae473e0dd6755ef4a79f34c1d493d1a0#egg=Flask-Admin

--- a/app/docker-quick/requirements.quick.txt
+++ b/app/docker-quick/requirements.quick.txt
@@ -1,0 +1,1 @@
+git+git://github.com/flask-admin/flask-admin@47d965fbae473e0dd6755ef4a79f34c1d493d1a0#egg=Flask-Admin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 app:
-#   build: app/
-    image: thegovlab/noi2:latest
+    build: app/docker-quick/
+#    image: thegovlab/noi2:latest
     command: /noi/run.sh
     links:
         - db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,5 @@
 app:
     build: app/docker-quick/
-#    image: thegovlab/noi2:latest
     command: /noi/run.sh
     links:
         - db


### PR DESCRIPTION
This is an attempt to make it easier to quickly iterate on dependencies for the `app` container (one of the recurring problems mentioned in #234).

Basically, `app/Dockerfile`, a.k.a. [thegovlab/noi2](https://hub.docker.com/r/thegovlab/noi2/) on Docker Hub, will be used as the "foundation" for the app container, but not all of it. A second, very lightweight container will sit atop it: this container normally will contain very few dependencies, if any, but it will be a place that devs can easily add or try out new dependencies, since the container will be so quick to rebuild.

As an example, the initial contents of this lightweight container in this PR add a very recent version of flask-admin directly from git, because it has new features (like CSV export) that aren't available in the version on PyPi. Rather than adding the git version to `app/requirements.txt` and then waiting about 10 minutes for the whole noi2 container to rebuild itself, we can instead add it to the lightweight container by adding the git version to `app/requirements.quick.txt`. Once it's confirmed to be the version that we definitely want to use, we can eventually move it to `app/requirements.txt`.

Things left to do:
* ~~Document this new behavior by updating the docker instructions in the readme.~~
* Somehow get a second opinion on this from someone more experienced with Docker?
