### PR TITLE
Always use postgres when running tests

### DIFF
--- a/app/tests/__init__.py
+++ b/app/tests/__init__.py
@@ -1,0 +1,3 @@
+def setup():
+    from .test_models import wait_until_db_is_ready
+    wait_until_db_is_ready()


### PR DESCRIPTION
Hopefully this fixes #23 forever, by adding [package-level test setup](http://nose.readthedocs.org/en/latest/writing_tests.html#test-packages) that waits for postgres to be up.

Unfortunately, the tests seem to run a lot slower with postgres, which is a bummer.