### PR TITLE
Use production.yml instead of NOI_ENVIRONMENT

### DIFF
--- a/conf/noi-environments/noi-.conf
+++ b/conf/noi-environments/noi-.conf
@@ -1,1 +1,0 @@
-include /etc/nginx/conf.d/noi-environments/noi-development.conf;

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-NOI_ENVIRONMENT=production docker-compose stop
-NOI_ENVIRONMENT=production docker-compose up -d
+docker-compose -f docker-compose.yml -f production.yml stop
+docker-compose -f docker-compose.yml -f production.yml up -d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,12 +9,12 @@ app:
         - ./migrations:/migrations
         - ./alchemydumps:/alchemydumps
     environment:
-        - NOI_ENVIRONMENT # unless production, assumed "development"
+        NOI_ENVIRONMENT: development
 db:
     image: postgres:9.4
 web:
     image: nginx
-    command: nginx -g "daemon off;" -c /etc/nginx/conf.d/noi-environments/noi-$NOI_ENVIRONMENT.conf
+    command: nginx -g "daemon off;" -c /etc/nginx/conf.d/noi-environments/noi-development.conf
     volumes:
         - ./conf/:/etc/nginx/conf.d/
         - ./app/static:/noi/app/static
@@ -23,4 +23,3 @@ web:
         - app
     ports:
         - "80:80"
-        - "443:443"

--- a/production.yml
+++ b/production.yml
@@ -1,0 +1,8 @@
+# https://docs.docker.com/compose/production/
+app:
+    environment:
+        NOI_ENVIRONMENT: production
+web:
+    command: nginx -g "daemon off;" -c /etc/nginx/conf.d/noi-environments/noi-production.conf
+    ports:
+        - "443:443"

--- a/run.sh
+++ b/run.sh
@@ -23,5 +23,5 @@ if [ "$NOI_ENVIRONMENT" == production ]; then
 else
     python /noi/manage.py db upgrade
     python /noi/manage.py translate_compile
-    NOI_ENVIRONMENT=development python /noi/develop.py
+    python /noi/develop.py
 fi


### PR DESCRIPTION
This switches us from using the manual setting of the `NOI_ENVIRONMENT` environment variable to determine whether or not to use production configuration over to a `production.yml` file, which is advised for [using Compose in production](https://docs.docker.com/compose/production/).

It also means that there won't be an annoying warning message about `NOI_ENVIRONMENT` being undefined every time docker-compose is run, which was introduced by c9a98f9caedc7b6769fddba2593dd4a2f7be94ca.
