### PR TITLE
change working dir of app container to /noi

### DIFF
--- a/app/noi1.py
+++ b/app/noi1.py
@@ -26,10 +26,8 @@ from app.models import (db, User, UserExpertiseDomain, UserLanguage,
                         UserSkill, UserJoinedEvent)
 
 MY_DIR = os.path.abspath(os.path.dirname(__file__))
-ROOT_DIR = os.path.normpath(os.path.join(MY_DIR, '..'))
 DATA_DIR = os.path.join(MY_DIR, 'noi1')
 
-rootpath = lambda *x: os.path.join(ROOT_DIR, *x)
 datapath = lambda *x: os.path.join(DATA_DIR, *x)
 
 USERS_FILE = datapath('users.json')
@@ -39,26 +37,10 @@ MIN_SKILLS = app.MIN_QUESTIONS_TO_JOIN
 
 users = None
 
-def make_path_absolute(filename):
-    '''
-    Convert the given user-supplied path to an absolute path.
-
-    Since we're probably being called in a docker container,
-    make the path absolute relative to the noi2 root directory, *not*
-    our current directory.
-    '''
-
-    if os.path.isabs(filename):
-        return filename
-
-    return rootpath(filename)
-
 class Noi1Manager(Manager):
     @staticmethod
     def __setup_globals(users_file):
         global users, users_with_skills, users_with_email
-
-        users_file = make_path_absolute(users_file)
 
         if users is not None:
             return
@@ -337,7 +319,7 @@ def csv_export(output_filename):
                 row[fieldname] = value.encode('utf-8')
         rows.append(row)
 
-    with open(make_path_absolute(output_filename), 'w') as csvfile:
+    with open(output_filename, 'w') as csvfile:
         writer = csv.DictWriter(csvfile, fieldnames)
         writer.writeheader()
         for row in rows:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,8 @@ app:
     build: app/docker-quick/
 # Uncomment the following line when testing the base Dockerfile.
 #    build: app/
-    command: /noi/run.sh
+    command: ./run.sh
+    working_dir: /noi
     links:
         - db
     volumes:

--- a/manage.sh
+++ b/manage.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -e
 
-docker-compose run app python /noi/manage.py $@
+docker-compose run app python manage.py $@

--- a/nosetests.sh
+++ b/nosetests.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -e
 
-docker-compose run --service-ports app nosetests -w /noi --with-doctest -I manage.py -I wsgi.py $@
+docker-compose run --service-ports app nosetests --with-doctest -I manage.py -I wsgi.py $@

--- a/run.sh
+++ b/run.sh
@@ -1,16 +1,14 @@
 #!/bin/bash
 
-python /noi/manage.py wait_for_db
-
 set -e
+
+python manage.py wait_for_db
+python manage.py db upgrade
+python manage.py translate_compile
+
 if [ "$NOI_ENVIRONMENT" == production ]; then
-    cd /noi
-    python manage.py db upgrade
-    python manage.py translate_compile
     python manage.py build_sass
     gunicorn wsgi:application -b 0.0.0.0:5000
 else
-    python /noi/manage.py db upgrade
-    python /noi/manage.py translate_compile
-    python /noi/develop.py
+    python develop.py
 fi


### PR DESCRIPTION
This sets the [working directory](https://docs.docker.com/engine/reference/run/#workdir) of the `app` container to `/noi`, which does a few things:

* Improves dev/prod parity by having them both use the same working directory (previously, dev's working dir was `/` during execution while production's was `/noi`)
* Reduces dependency on hard-coding `/noi` as an absolute path, which could eventually make it easier to run the app outside of a Docker container (#234) if we want.
* Makes a number of scripts a bit less verbose.
* Reduces the need for workarounds that convert relative paths from the noi root dir on the docker host to paths on the container (e.g. 406cc97aab838f37ec77a12eb7c30e991b294dea).
