### PR TITLE
Allow users w/ emails to be deleted.

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -709,6 +709,11 @@ class Email(db.Model): #pylint: disable=no-init,too-few-public-methods
 
     from_user_id = Column(types.Integer, ForeignKey('users.id'), nullable=False)
     to_user_id = Column(types.Integer, ForeignKey('users.id'), nullable=False)
+    from_user = orm.relationship('User', foreign_keys=[from_user_id],
+        backref=orm.backref('emails_sent', cascade='all, delete-orphan'))
+    to_user = orm.relationship('User', foreign_keys=[to_user_id],
+        backref=orm.backref('emails_received', cascade='all, delete-orphan'))
+
     connection_event_id = Column(types.Integer, ForeignKey('events.id'),
                                  nullable=False)
     connection_event = orm.relationship('ConnectionEvent', backref=orm.backref(

--- a/app/tests/test_models.py
+++ b/app/tests/test_models.py
@@ -902,6 +902,30 @@ class UserConnectionDbTests(DbTestCase):
         db.session.commit()
         self.assertEquals(self.sly_less.connections, 1)
 
+    def test_user_disconnect_on_sender_deletion(self):
+        '''
+        When a sender is deleted, their related connections disappear.
+        '''
+
+        self.sly_less.email_connect([self.dubya_shrub])
+        db.session.commit()
+
+        db.session.delete(self.sly_less)
+        db.session.commit()
+        self.assertEquals(self.dubya_shrub.connections, 0)
+
+    def test_user_disconnect_on_recipient_deletion(self):
+        '''
+        When a recipient is deleted, their related connections disappear.
+        '''
+
+        self.sly_less.email_connect([self.dubya_shrub])
+        db.session.commit()
+
+        db.session.delete(self.dubya_shrub)
+        db.session.commit()
+        self.assertEquals(self.sly_less.connections, 0)
+
     def test_user_connect_on_email_several(self):
         '''
         A user gains several connections on emailing several people.

--- a/manage.py
+++ b/manage.py
@@ -259,6 +259,12 @@ def populate_db(count=50):
     return 0
 
 @manager.command
+def show_db_create_table_sql():
+    from app.tests.test_models import get_postgres_create_table_sql
+
+    print get_postgres_create_table_sql()
+
+@manager.command
 def build_sass():
     """
     Build SASS files.


### PR DESCRIPTION
This fixes #260.

Things to do:

- [X] ~~It's possible that no database migration is required for this as running `manage.py db migrate` generates an empty migration file. Which is a bit odd because I believe [Postgres supports `ON DELETE CASCADE`](http://www.postgresql.org/docs/8.2/static/ddl-constraints.html). So I'll have to double-check that Alembic's auto-migration code isn't blind to such schema changes.~~ [See below](https://github.com/GovLab/noi2/pull/261#issuecomment-173650587).

- [ ] While this allows users with emails to be deleted by deleting all `Email`s the user has ever sent or received, it doesn't delete `ConnectionEvent` models when they have no emails in them. This means that it's possible for empty `ConnectionEvent` instances to be lying around, if one or more of the users in ther emails gets deleted. I'm not sure how to deal with this; if there's a way to tell Postgres/SQLAlchemy "hey, when stuff is deleted, also delete this if it's empty", then we'll do that, obviously--but if there's no way to do that, we might have to schedule a cleanup task to get rid of all empty `ConnectionEvent`s periodically.
