### PR TITLE
Add LinkedIn integration.

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -13,6 +13,7 @@ from flask_bcrypt import Bcrypt
 from flask_mail import Mail
 from flask_s3 import FlaskS3
 from flask_wtf.csrf import CsrfProtect
+from flask_oauthlib.client import OAuth
 
 from babel import Locale, UnknownLocaleError
 import locale
@@ -26,6 +27,7 @@ security = Security()
 csrf = CsrfProtect()
 babel = Babel()
 bcrypt = Bcrypt()
+oauth = OAuth()
 
 assets = Environment()
 

--- a/app/config/local_config.sample.yml
+++ b/app/config/local_config.sample.yml
@@ -107,6 +107,10 @@ SECRET_KEY: i_am_insecure
 #
 #   * r_basicprofile
 #
+# You will also need to add the absolute URL to /linkedin/callback on
+# your NoI installation to the list of OAuth 2.0 Authorized Redirect URLs
+# in your app's configuration screen.
+#
 # LINKEDIN:
 #   consumer_key: something
 #   consumer_secret: somethingelse

--- a/app/config/local_config.sample.yml
+++ b/app/config/local_config.sample.yml
@@ -94,3 +94,19 @@ SECRET_KEY: i_am_insecure
 # This specifies a Pingdom Real User Monitoring (RUM) ID.
 #
 # PINGDOM_RUM_ID: blahblahblah
+
+# LinkedIn Connectivity
+# ---------------------
+
+# This specifies the LinkedIn credentials for optional LinkedIn
+# connectivity.
+#
+# To obtain these, you will need to set up a new LinkedIn third-party
+# app at https://developer.linkedin.com/my-apps. The app should have
+# the following permissions:
+#
+#   * r_basicprofile
+#
+# LINKEDIN:
+#   consumer_key: something
+#   consumer_secret: somethingelse

--- a/app/docker-quick/requirements.quick.txt
+++ b/app/docker-quick/requirements.quick.txt
@@ -1,2 +1,4 @@
 feedparser==5.2.1
 bleach==1.4.2
+Flask-OAuthlib==0.9.2
+mock==1.3.0

--- a/app/factory.py
+++ b/app/factory.py
@@ -10,7 +10,8 @@ from flask_security import SQLAlchemyUserDatastore, user_registered
 from flask_security.utils import get_identity_attributes
 
 from app import (csrf, cache, mail, bcrypt, s3, assets, security, admin,
-                 babel, alchemydumps, sass, email_errors, csp,
+                 babel, alchemydumps, sass, email_errors, csp, oauth,
+                 linkedin,
                  QUESTIONNAIRES, NOI_COLORS, LEVELS, ORG_TYPES,
                  QUESTIONS_BY_ID, LEVELS_BY_SCORE, QUESTIONNAIRES_BY_ID)
 from app.forms import (NOIForgotPasswordForm, NOILoginForm,
@@ -100,6 +101,11 @@ def create_app(config=None): #pylint: disable=too-many-statements
 
     if not app.config['DEBUG'] and app.config.get('ADMINS'):
         email_errors.init_app(app)
+
+    oauth.init_app(app)
+    if 'LINKEDIN' in app.config:
+        app.jinja_env.globals['LINKEDIN_ENABLED'] = True
+        app.register_blueprint(linkedin.views)
 
     cache.init_app(app)
     csrf.init_app(app)

--- a/app/linkedin.py
+++ b/app/linkedin.py
@@ -18,6 +18,36 @@ from flask import current_app, request
 # server.
 MIN_TOKEN_LIFETIME = 120
 
+# These are the user info fields to retrieve for users from LinkedIn.
+# For more information, see:
+#
+#     https://developer.linkedin.com/docs/fields/basic-profile
+#
+USER_INFO_FIELDS = [
+    'id',
+    'first-name',
+    'last-name',
+    'maiden-name',
+    'formatted-name',
+    'phonetic-first-name',
+    'phonetic-last-name',
+    'formatted-phonetic-name',
+    'headline',
+    'location',
+    'industry',
+    'current-share',
+    'num-connections',
+    'num-connections-capped',
+    'summary',
+    'specialties',
+    'positions',
+    'picture-url',
+    'picture-urls::(original)',
+    'site-standard-profile-request',
+    'api-standard-profile-request',
+    'public-profile-url',
+]
+
 linkedin = oauth.remote_app(
     'linkedin',
     app_key='LINKEDIN',
@@ -52,10 +82,10 @@ def store_access_token(user, resp):
     db.session.commit()
 
 def get_user_info(user):
-    return linkedin.get(
-        'v1/people/~?format=json',
-        token=retrieve_access_token(user)
-    ).data
+    # https://developer-programs.linkedin.com/documents/field-selectors
+    url = 'v1/people/~:(%s)?format=json' % ','.join(USER_INFO_FIELDS)
+
+    return linkedin.get(url, token=retrieve_access_token(user)).data
 
 @views.route('/linkedin/authorize')
 @login_required

--- a/app/linkedin.py
+++ b/app/linkedin.py
@@ -3,6 +3,7 @@ import datetime
 from flask import Blueprint, flash, redirect, url_for, session
 from flask_login import login_required, current_user
 from flask_babel import gettext
+from flask_oauthlib.client import OAuthException
 from werkzeug.security import gen_salt
 
 from app import oauth
@@ -85,7 +86,15 @@ def get_user_info(user):
     # https://developer-programs.linkedin.com/documents/field-selectors
     url = 'v1/people/~:(%s)?format=json' % ','.join(USER_INFO_FIELDS)
 
-    return linkedin.get(url, token=retrieve_access_token(user)).data
+    res = linkedin.get(url, token=retrieve_access_token(user))
+
+    if res.status != 200:
+        raise OAuthException('Server returned HTTP %d: %s' % (
+            res.status,
+            repr(res.data)
+        ), data=res.data)
+
+    return res.data
 
 @views.route('/linkedin/authorize')
 @login_required

--- a/app/linkedin.py
+++ b/app/linkedin.py
@@ -1,0 +1,36 @@
+from flask import Blueprint, flash, redirect, url_for
+from flask_babel import gettext
+from werkzeug.security import gen_salt
+
+from app import oauth
+
+linkedin = oauth.remote_app(
+    'linkedin',
+    app_key='LINKEDIN',
+    request_token_url=None,
+    request_token_params={
+        'scope': 'r_basicprofile',
+        'state': lambda: gen_salt(10)
+    },
+    base_url='https://api.linkedin.com/',
+    authorize_url='https://www.linkedin.com/uas/oauth2/authorization',
+    access_token_method='POST',
+    access_token_url='https://www.linkedin.com/uas/oauth2/accessToken',
+)
+
+views = Blueprint('linkedin', __name__)
+
+@views.route('/linkedin/authorize')
+def authorize():
+    return linkedin.authorize(
+        callback=url_for('linkedin.callback', _external=True)
+    )
+
+@views.route('/linkedin/callback')
+def callback():
+    resp = linkedin.authorized_response()
+    if resp is None:
+        flash(gettext(u'Connection with LinkedIn canceled.'), 'error')
+    else:
+        flash(gettext(u'Connection to LinkedIn established.'))
+    return redirect(url_for('views.my_profile'))

--- a/app/linkedin.py
+++ b/app/linkedin.py
@@ -106,7 +106,7 @@ def get_user_info(user):
 def update_user_fields_from_profile(user, info):
     location = info.get('location')
     if location:
-        if 'name' in location and user.city is None:
+        if 'name' in location and not user.city:
             user.city = location['name']
         if 'country' in location and 'code' in location['country']:
             country_code = location['country']['code'].upper()
@@ -114,6 +114,8 @@ def update_user_fields_from_profile(user, info):
                 user.country = Country(country_code)
             except ValueError:
                 pass
+    if info.get('headline') and not user.position:
+        user.position = info['headline']
 
 def update_user_info(user):
     info = get_user_info(user)

--- a/app/linkedin.py
+++ b/app/linkedin.py
@@ -86,8 +86,14 @@ def store_access_token(user, resp):
 def get_user_info(user):
     # https://developer-programs.linkedin.com/documents/field-selectors
     url = 'v1/people/~:(%s)?format=json' % ','.join(USER_INFO_FIELDS)
+    token = retrieve_access_token(user)
 
-    res = linkedin.get(url, token=retrieve_access_token(user))
+    if token is None:
+        raise OAuthException(
+            'Access token unavailable or expired for %s' % user.email
+        )
+
+    res = linkedin.get(url, token=token)
 
     if res.status != 200:
         raise OAuthException('Server returned HTTP %d: %s' % (

--- a/app/linkedin.py
+++ b/app/linkedin.py
@@ -1,4 +1,5 @@
 from flask import Blueprint, flash, redirect, url_for, session
+from flask_login import login_required, current_user
 from flask_babel import gettext
 from werkzeug.security import gen_salt
 
@@ -23,6 +24,7 @@ linkedin = oauth.remote_app(
 views = Blueprint('linkedin', __name__)
 
 @views.route('/linkedin/authorize')
+@login_required
 def authorize():
     session['linkedin_state'] = gen_salt(10)
     return linkedin.authorize(
@@ -30,6 +32,7 @@ def authorize():
     )
 
 @views.route('/linkedin/callback')
+@login_required
 def callback():
     state = request.args.get('state')
     if not state or session.get('linkedin_state') != state:

--- a/app/models.py
+++ b/app/models.py
@@ -817,3 +817,15 @@ class Noi1MigrationInfo(db.Model):
     noi1_userid = Column(types.String)
     noi1_json = Column(types.Text)
     email_sent_at = Column(types.DateTime())
+
+
+class LinkedinInfo(db.Model):
+    __tablename__ = 'linkedin_info'
+
+    id = Column(types.Integer, primary_key=True)
+    user_id = Column(types.Integer, ForeignKey('users.id'))
+    user = orm.relationship(
+        'User',
+        backref=orm.backref('linkedin_info', cascade='all,delete-orphan',
+                            uselist=False)
+    )

--- a/app/models.py
+++ b/app/models.py
@@ -15,6 +15,7 @@ from flask_babel import lazy_gettext
 
 from sqlalchemy import (orm, types, Column, ForeignKey, UniqueConstraint, func,
                         desc, cast, String)
+from sqlalchemy.dialects.postgresql import JSON
 from sqlalchemy.orm import aliased
 from sqlalchemy_utils import EmailType, CountryType, LocaleType
 from sqlalchemy.ext.hybrid import hybrid_property
@@ -833,6 +834,13 @@ class UserLinkedinInfo(db.Model):
     access_token = Column(types.String, nullable=False)
     access_token_expiry = Column(types.DateTime(), nullable=False)
 
+    user_info = Column(JSON)
+
     @property
     def expires_in(self):
         return self.access_token_expiry - datetime.datetime.now()
+
+    @property
+    def profile_url(self):
+        if self.user_info:
+            return self.user_info.get('publicProfileUrl')

--- a/app/models.py
+++ b/app/models.py
@@ -853,3 +853,18 @@ class UserLinkedinInfo(db.Model):
     def profile_url(self):
         if self.user_info:
             return self.user_info.get('publicProfileUrl')
+
+    @property
+    def picture_url(self):
+        info = self.user_info
+        if info:
+            # Attempt to get a high-resolution image first.
+            if 'pictureUrls' in info:
+                picture_urls = info['pictureUrls']
+                if picture_urls.get('values'):
+                    # Not really sure which one will be highest-res, so
+                    # we'll just pick the first.
+                    return picture_urls['values'][0]
+
+            # This is generally *really* low-res.
+            return info.get('pictureUrl')

--- a/app/models.py
+++ b/app/models.py
@@ -205,6 +205,15 @@ class User(db.Model, UserMixin, DeploymentMixin): #pylint: disable=no-init,too-f
             path=self.picture_path
         )
 
+    def remove_picture(self):
+        conn = S3Connection(current_app.config['S3_ACCESS_KEY_ID'],
+                            current_app.config['S3_SECRET_ACCESS_KEY'])
+        bucket = conn.get_bucket(current_app.config['S3_BUCKET_NAME'])
+
+        bucket.delete_key(self.picture_path)
+
+        self.has_picture = False
+
     def upload_picture(self, fileobj, mimetype):
         '''
         Upload the given file object with the given mime type to S3 and

--- a/app/models.py
+++ b/app/models.py
@@ -210,7 +210,8 @@ class User(db.Model, UserMixin, DeploymentMixin): #pylint: disable=no-init,too-f
                             current_app.config['S3_SECRET_ACCESS_KEY'])
         bucket = conn.get_bucket(current_app.config['S3_BUCKET_NAME'])
 
-        bucket.delete_key(self.picture_path)
+        if bucket.get_key(self.picture_path):
+            bucket.delete_key(self.picture_path)
 
         self.has_picture = False
 

--- a/app/models.py
+++ b/app/models.py
@@ -819,13 +819,20 @@ class Noi1MigrationInfo(db.Model):
     email_sent_at = Column(types.DateTime())
 
 
-class LinkedinInfo(db.Model):
-    __tablename__ = 'linkedin_info'
+class UserLinkedinInfo(db.Model):
+    __tablename__ = 'user_linkedin_info'
 
     id = Column(types.Integer, primary_key=True)
     user_id = Column(types.Integer, ForeignKey('users.id'))
     user = orm.relationship(
         'User',
-        backref=orm.backref('linkedin_info', cascade='all,delete-orphan',
+        backref=orm.backref('linkedin', cascade='all,delete-orphan',
                             uselist=False)
     )
+
+    access_token = Column(types.String, nullable=False)
+    access_token_expiry = Column(types.DateTime(), nullable=False)
+
+    @property
+    def expires_in(self):
+        return self.access_token_expiry - datetime.datetime.now()

--- a/app/static/js/pages/my-profile.js
+++ b/app/static/js/pages/my-profile.js
@@ -28,6 +28,7 @@ $('#picture').on('change', function (evt) {
       loadImage(this.files[0], function(canvas) {
         upload(canvas, function() {
           $(self).val('');
+          $removePicture.fadeIn();
         });
       }, {
         maxWidth: 256,
@@ -38,4 +39,22 @@ $('#picture').on('change', function (evt) {
       });
     }
   }
+});
+
+var $removePicture = $('[data-remove-picture]');
+
+$removePicture.on('click', function(evt) {
+  if (!window.confirm("Do you really want to remove your profile picture?"))
+    return;
+  $.ajax({
+    url: '/me/picture/remove',
+    type: 'POST',
+    success: function(data, textStatus) {
+      alert('Your profile picture has been removed.');
+      $removePicture.fadeOut();
+    },
+    error: function() {
+      alert('An error occurred when deleting your profile picture.');
+    }
+  });
 });

--- a/app/static/js/pages/my-profile.js
+++ b/app/static/js/pages/my-profile.js
@@ -44,17 +44,17 @@ $('#picture').on('change', function (evt) {
 var $removePicture = $('[data-remove-picture]');
 
 $removePicture.on('click', function(evt) {
-  if (!window.confirm("Do you really want to remove your profile picture?"))
+  if (!window.confirm(pageConfig.REMOVE_PICTURE_CONFIRM))
     return;
   $.ajax({
-    url: '/me/picture/remove',
+    url: pageConfig.REMOVE_PICTURE_URL,
     type: 'POST',
     success: function(data, textStatus) {
-      alert('Your profile picture has been removed.');
+      alert(pageConfig.REMOVE_PICTURE_SUCCESS);
       $removePicture.fadeOut();
     },
     error: function() {
-      alert('An error occurred when deleting your profile picture.');
+      alert(pageConfig.REMOVE_PICTURE_ERROR);
     }
   });
 });

--- a/app/templates/_macros.html
+++ b/app/templates/_macros.html
@@ -1,6 +1,8 @@
 {% macro get_user_avatar_url(user) -%}
 {% if user.has_picture -%}
 {{ user.picture_url }}
+{%- elif user.linkedin and user.linkedin.picture_url -%}
+{{ user.linkedin.picture_url }}
 {%- else -%}
 {{ get_nopic_avatar(user.email) }}
 {%- endif %}

--- a/app/templates/my-profile.html
+++ b/app/templates/my-profile.html
@@ -28,6 +28,22 @@
 {% endif %}
 {%- endmacro %}
 
+{% if LINKEDIN_ENABLED and not current_user.linkedin %}
+<p>
+  <a class="b-button" href="{{ url_for('linkedin.authorize') }}">
+    Connect to <img alt="LinkedIn" src="https://upload.wikimedia.org/wikipedia/commons/thumb/c/ca/LinkedIn_logo_initials.png/768px-LinkedIn_logo_initials.png" width="16" style="vertical-align: bottom; margin-bottom: 4px;">
+  </a>
+</p>
+
+<p>
+  <small>
+  Connecting your account to LinkedIn&trade; will allow you to pre-fill some of
+  the form fields below. It will also allow others to see your LinkedIn&trade;
+  profile.
+  </small>
+</p>
+{% endif %}
+
 {{ input("picture") }}
 {{ input("first_name") }}
 {{ input("last_name") }}
@@ -45,6 +61,14 @@
 <button type="submit">{{ gettext('Save') }}</button>
 
 </form>
+
+{% if LINKEDIN_ENABLED and current_user.linkedin %}
+<div class="b-temporary-styling">
+  <small>
+  Your account is currently connected to LinkedIn&trade;, which allows others to see your LinkedIn&trade; profile. You can <a style="text-decoration: underline" href="{{ url_for('linkedin.deauthorize') }}">disconnect from LinkedIn&trade;</a> at any time to disable this.
+  </small>
+</div>
+{% endif %}
 
 {% endblock %}
 

--- a/app/templates/my-profile.html
+++ b/app/templates/my-profile.html
@@ -19,6 +19,9 @@
 {% else %}
   {{ form[name](placeholder=form[name].description) }}
 {% endif %}
+{% if name == "picture" %}
+<a data-remove-picture href="#" class="material-icons" style="float: right;{% if not current_user.has_picture %}display: none{% endif %}">clear</a>
+{% endif %}
 {% if form[name].errors %}
   <ul class="list-unstyled">
   {% for error in form[name].errors %}

--- a/app/templates/user-profile.html
+++ b/app/templates/user-profile.html
@@ -31,6 +31,11 @@ b-public-profile
         <img src="{{ get_user_avatar_url(user) }}" alt="" class="e-picture">
         {% call render_user_mailto_link(user) %}<span class="e-send material-icons">send</span>{% endcall %}
         {% endif %}
+
+        {% if user.linkedin and user.linkedin.profile_url %}
+        <a href="{{ user.linkedin.profile_url }}" target="_blank" class="e-edit"><img src="https://upload.wikimedia.org/wikipedia/commons/thumb/c/ca/LinkedIn_logo_initials.png/768px-LinkedIn_logo_initials.png" width="24"></a>
+        {% endif %}
+
     </div>
     <div class="e-right">
         <h2 class="e-name">{{ user.full_name }}</h2>

--- a/app/templates/user-profile.html
+++ b/app/templates/user-profile.html
@@ -33,7 +33,7 @@ b-public-profile
         {% endif %}
 
         {% if user.linkedin and user.linkedin.profile_url %}
-        <a href="{{ user.linkedin.profile_url }}" target="_blank" class="e-edit"><img src="https://upload.wikimedia.org/wikipedia/commons/thumb/c/ca/LinkedIn_logo_initials.png/768px-LinkedIn_logo_initials.png" width="24"></a>
+        <a href="{{ user.linkedin.profile_url }}" target="_blank" class="e-edit"><img src="https://upload.wikimedia.org/wikipedia/commons/thumb/c/ca/LinkedIn_logo_initials.png/768px-LinkedIn_logo_initials.png" alt="LinkedIn" width="24"></a>
         {% endif %}
 
     </div>

--- a/app/tests/test_linkedin.py
+++ b/app/tests/test_linkedin.py
@@ -104,6 +104,12 @@ class LinkedinDbTests(DbTestCase):
         linkedin.store_access_token(self.user, FAKE_AUTHORIZED_RESPONSE)
         self.assertEqual(UserLinkedinInfo.query.count(), 1)
 
+    def test_headline_is_imported_from_profile(self):
+        linkedin.update_user_fields_from_profile(self.user, {
+            u'headline': 'Awesome Person'
+        })
+        self.assertEqual(self.user.position, 'Awesome Person')
+
     def test_unrecognized_country_name_in_profile_is_ignored(self):
         linkedin.update_user_fields_from_profile(self.user, {
             u'location': {u'country': {u'code': u'lolol'}},

--- a/app/tests/test_linkedin.py
+++ b/app/tests/test_linkedin.py
@@ -1,0 +1,52 @@
+import mock
+
+from .. import linkedin
+from  .test_views import ViewTestCase
+
+class LinkedInDisabledTests(ViewTestCase):
+    def test_linkedin_is_disabled_if_setting_not_present(self):
+        self.assertTrue('LINKEDIN_ENABLED' not in self.app.jinja_env.globals)
+
+    def test_authorize_is_404(self):
+        res = self.client.get('/linkedin/authorize')
+        self.assert404(res)
+
+class LinkedInTests(ViewTestCase):
+    BASE_APP_CONFIG = ViewTestCase.BASE_APP_CONFIG.copy()
+
+    BASE_APP_CONFIG['LINKEDIN'] = dict(
+        consumer_key='ckey',
+        consumer_secret='csecret',
+    )
+
+    def test_linkedin_is_enabled_if_setting_present(self):
+        self.assertTrue(self.app.jinja_env.globals['LINKEDIN_ENABLED'])
+
+    @mock.patch.object(linkedin, 'gen_salt', return_value='boop')
+    def test_authorize_redirects_to_linkedin(self, gen_salt):
+        res = self.client.get('/linkedin/authorize')
+        self.assertEqual(res.status_code, 302)
+        self.assertEqual(
+            res.headers['location'],
+            'https://www.linkedin.com/uas/oauth2/authorization?'
+            'response_type=code&client_id=ckey&'
+            'redirect_uri=http%3A%2F%2Flocalhost%2Flinkedin%2Fcallback&'
+            'scope=r_basicprofile&state=boop'
+        )
+        gen_salt.assert_called_with(10)
+
+    @mock.patch.object(linkedin.linkedin, 'authorized_response',
+                       return_value=None)
+    def test_failed_callback_flashes_error(self, authorized_response):
+        res = self.client.get('/linkedin/callback', follow_redirects=True)
+        self.assert200(res)
+        authorized_response.assert_called_once_with()
+        assert "Connection with LinkedIn canceled" in res.data
+
+    @mock.patch.object(linkedin.linkedin, 'authorized_response',
+                       return_value={'something': True})
+    def test_successful_callback_works(self, authorized_response):
+        res = self.client.get('/linkedin/callback', follow_redirects=True)
+        self.assert200(res)
+        authorized_response.assert_called_once_with()
+        assert "Connection to LinkedIn established" in res.data

--- a/app/tests/test_linkedin.py
+++ b/app/tests/test_linkedin.py
@@ -1,5 +1,6 @@
 import datetime
 import mock
+from unittest import TestCase
 
 from .. import linkedin
 from ..models import User, db, UserLinkedinInfo
@@ -19,7 +20,33 @@ class LinkedinDisabledTests(ViewTestCase):
         res = self.client.get('/linkedin/authorize')
         self.assert404(res)
 
-class LinkedinModelTests(DbTestCase):
+class UserLinkedinInfoTests(TestCase):
+    def test_profile_url_is_none_if_not_available(self):
+        info = UserLinkedinInfo()
+        self.assertEqual(info.profile_url, None)
+
+    def test_profile_url_works(self):
+        info = UserLinkedinInfo(user_info={'publicProfileUrl': 'http://u'})
+        self.assertEqual(info.profile_url, 'http://u')
+
+    def test_picture_url_is_high_res_if_available(self):
+        info = UserLinkedinInfo(user_info={
+            'pictureUrls': {
+                'values': ['http://a', 'http://b']
+            },
+            'pictureUrl': 'http://c'
+        })
+        self.assertEqual(info.picture_url, 'http://a')
+
+    def test_picture_url_falls_back_to_low_res(self):
+        info = UserLinkedinInfo(user_info={'pictureUrl': 'http://c'})
+        self.assertEqual(info.picture_url, 'http://c')
+
+    def test_picture_url_is_none_if_not_available(self):
+        info = UserLinkedinInfo()
+        self.assertEqual(info.picture_url, None)
+
+class LinkedinDbTests(DbTestCase):
     def setUp(self):
         super(LinkedinModelTests, self).setUp()
         self.user = User(email=u'a@example.org', password='a', active=True)

--- a/app/tests/test_linkedin.py
+++ b/app/tests/test_linkedin.py
@@ -1,3 +1,4 @@
+import datetime
 import mock
 
 from .. import linkedin
@@ -72,8 +73,17 @@ class LinkedInTests(ViewTestCase):
         assert "Connection with LinkedIn canceled" in res.data
 
     def test_successful_callback_works(self):
-        res = self.get_callback(fake_response={'something': True})
+        res = self.get_callback(fake_response={
+            'access_token': 'blorp',
+            'expires_in': 10000
+        })
         self.assert200(res)
+
+        user = self.last_created_user
+        self.assertEqual(user.linkedin.access_token, 'blorp')
+        self.assertAlmostEqual(user.linkedin.expires_in.total_seconds(),
+                               10000, delta=120)
+
         assert "Connection to LinkedIn established" in res.data
 
     def test_authorize_requires_login(self):

--- a/app/tests/test_linkedin.py
+++ b/app/tests/test_linkedin.py
@@ -48,7 +48,7 @@ class UserLinkedinInfoTests(TestCase):
 
 class LinkedinDbTests(DbTestCase):
     def setUp(self):
-        super(LinkedinModelTests, self).setUp()
+        super(LinkedinDbTests, self).setUp()
         self.user = User(email=u'a@example.org', password='a', active=True)
         db.session.add(self.user)
         db.session.commit()

--- a/app/tests/test_linkedin.py
+++ b/app/tests/test_linkedin.py
@@ -53,6 +53,13 @@ class LinkedinDbTests(DbTestCase):
         db.session.add(self.user)
         db.session.commit()
 
+    def test_linkedin_is_deleted_with_user(self):
+        linkedin.store_access_token(self.user, FAKE_AUTHORIZED_RESPONSE)
+        self.assertEqual(UserLinkedinInfo.query.count(), 1)
+        db.session.delete(self.user)
+        db.session.commit()
+        self.assertEqual(UserLinkedinInfo.query.count(), 0)
+
     def test_only_one_linkedin_per_user_is_created(self):
         self.assertEqual(UserLinkedinInfo.query.count(), 0)
         linkedin.store_access_token(self.user, FAKE_AUTHORIZED_RESPONSE)

--- a/app/tests/test_views.py
+++ b/app/tests/test_views.py
@@ -1,4 +1,5 @@
 from StringIO import StringIO
+from urllib import urlencode
 from moto import mock_s3
 import boto
 
@@ -75,6 +76,11 @@ class ViewTestCase(DbTestCase):
         self.assert200(res)
         assert LOGGED_IN_SENTINEL in res.data
         return res
+
+    def assertRequiresLogin(self, path, method='get'):
+        method = getattr(self.client, method)
+        self.assertRedirects(method(path),
+                             '/login?%s' % urlencode({'next': path}))
 
 class InviteTests(ViewTestCase):
     BASE_APP_CONFIG = ViewTestCase.BASE_APP_CONFIG.copy()
@@ -653,8 +659,7 @@ class ViewTests(ViewTestCase):
         self.assert200(res)
 
     def test_user_profiles_require_login(self):
-        self.assertRedirects(self.client.get('/user/1234'),
-                             '/login?next=%2Fuser%2F1234')
+        self.assertRequiresLogin('/user/1234')
 
     def test_empty_match_results_are_ok(self):
         self.login()

--- a/app/tests/test_views.py
+++ b/app/tests/test_views.py
@@ -603,11 +603,15 @@ class UploadPictureTests(ViewTestCase):
     @mock_s3
     def test_remove_picture_works_if_picture_exists(self):
         self.init_s3()
+
+        self.last_created_user.has_picture = True
         k = self.bucket.new_key(self.picture_path)
         k.set_contents_from_string('hi')
+
         res = self.client.post('/me/picture/remove')
         self.assertEqual(res.status_code, 204)
         self.assertIsNone(self.bucket.get_key(self.picture_path))
+        self.assertFalse(self.last_created_user.has_picture)
 
     @mock_s3
     def test_valid_form_sets_picture(self):

--- a/app/views.py
+++ b/app/views.py
@@ -107,6 +107,13 @@ def set_user_picture(user, picture):
         mimetype=mimetypes.guess_type(picture.data.filename)[0]
     )
 
+@views.route('/me/picture/remove', methods=['POST'])
+@full_registration_required
+def my_profile_remove_picture():
+    current_user.remove_picture()
+    db.session.commit()
+    return ('', 204)
+
 @views.route('/me/picture', methods=['POST'])
 @full_registration_required
 def my_profile_upload_picture():

--- a/app/views.py
+++ b/app/views.py
@@ -158,7 +158,11 @@ def my_profile():
         page_config_json=json_blob(
             UPLOAD_PICTURE_URL=url_for('views.my_profile_upload_picture'),
             UPLOAD_PICTURE_SUCCESS=gettext("Your user picture has been changed."),
-            UPLOAD_PICTURE_ERROR=gettext("An error occurred when uploading your user picture.")
+            UPLOAD_PICTURE_ERROR=gettext("An error occurred when uploading your user picture."),
+            REMOVE_PICTURE_URL=url_for('views.my_profile_remove_picture'),
+            REMOVE_PICTURE_CONFIRM=gettext("Do you really want to remove your profile picture?"),
+            REMOVE_PICTURE_SUCCESS=gettext("Your profile picture has been removed."),
+            REMOVE_PICTURE_ERROR=gettext("An error occurred when removing your profile picture."),
         )
     )
 

--- a/manage.py
+++ b/manage.py
@@ -266,9 +266,9 @@ def show_db_create_table_sql():
     print get_postgres_create_table_sql()
 
 @manager.command
-def show_linkedin_info(email):
+def refresh_linkedin_info(email):
     """
-    Retrieve and display LinkedIn information for a user.
+    Refresh and display LinkedIn information for a user.
     """
 
     user = User.query_in_deployment().filter_by(email=email).one()
@@ -276,7 +276,8 @@ def show_linkedin_info(email):
         raise InvalidCommand(
             'The user must first (re)connect to LinkedIn on the website.'
         )
-    pprint.pprint(linkedin.get_user_info(user))
+    linkedin.update_user_info(user)
+    pprint.pprint(user.linkedin.user_info)
 
 @manager.command
 def show_blog_posts():

--- a/manage.py
+++ b/manage.py
@@ -5,7 +5,7 @@ Scripts to run the server and perform maintenance operations
 '''
 
 from app import (mail, models, sass, email_errors, LEVELS, ORG_TYPES, stats,
-                 questionnaires, blog_posts)
+                 questionnaires, blog_posts, linkedin)
 from app.factory import create_app
 from app.models import db, User
 from app.utils import csv_reader
@@ -264,6 +264,19 @@ def show_db_create_table_sql():
     from app.tests.test_models import get_postgres_create_table_sql
 
     print get_postgres_create_table_sql()
+
+@manager.command
+def show_linkedin_info(email):
+    """
+    Retrieve and display LinkedIn information for a user.
+    """
+
+    user = User.query_in_deployment().filter_by(email=email).one()
+    if linkedin.retrieve_access_token(user) is None:
+        raise InvalidCommand(
+            'The user must first (re)connect to LinkedIn on the website.'
+        )
+    pprint.pprint(linkedin.get_user_info(user))
 
 @manager.command
 def show_blog_posts():


### PR DESCRIPTION
Still to do:
- [x] Make sure `state` is actually checked in the callback so we protect from CSRF attacks. (Good thing this was investigated, given https://github.com/lepture/flask-oauthlib/issues/206 .)
- [x] On success, actually grab the user's profile URL and store it in the db.
- [x] ~~On success, grab the user's avatar **only if they don't already have one**, and upload it to S3 and make sure the DB knows they have a pic now.~~ When displaying user avatars, fall back to the user's linkedin avatar before falling back to one of the "no user picture available" avatars.
- [x] It will be easier to manually test the avatar-setting functionality if we make it possible for users to *remove* their avatars... Not a requirement, though.
- [x] Add a section to the profile edit page that lets the user **connect** their account to linkedin *only if* linkedIn connectivity is enabled.
- [x] Add a section to the profile edit page that lets the user **disconnect** their account from linkedin *only if* linkedIn connectivity is enabled.
- [X] Add a `manage.py refresh_linkedin_info` command that can be used to quickly manually test LinkedIn integration.
- [X] Store the LinkedIn access token in the database, so we can do things with it after the user has connected (well, at least [for 60 days after the user connects](https://developer.linkedin.com/docs/oauth2)). 
- [x] Ensure that the user is logged in on the authorize and callback endpoints.
- [x] Make the user's "position" field be filled from the user's LinkedIn headline if empty.
- [x] Add a test for `views.my_profile_remove_picture`.
- [X] ~~The UI here is temporary right now; in particular, text isn't internationalized yet, and we're embedding a LinkedIn logo directly from WikiMedia Commons, which we'll want to replace with our own self-hosted one. Either fix this or file a bug for it. (Probably the latter, since the UI will evolve based on Batu's feedback.)~~ Filed as #273.