### PR TITLE
Run docker commands under same uid as host.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
   - docker
 
 before_install:
-  - curl -L https://github.com/docker/compose/releases/download/1.4.0/docker-compose-`uname -s`-`uname -m` > docker-compose
+  - curl -L https://github.com/docker/compose/releases/download/1.5.2/docker-compose-`uname -s`-`uname -m` > docker-compose
   - chmod +x docker-compose
   - sudo mv docker-compose /usr/local/bin
 

--- a/app/linkedin.py
+++ b/app/linkedin.py
@@ -114,6 +114,16 @@ def update_user_fields_from_profile(user, info):
                 user.country = Country(country_code)
             except ValueError:
                 pass
+
+    positions = info.get('positions')
+    if positions and len(positions.get('values', [])) >= 1:
+        position = positions['values'][0]
+        org = position.get('company') and position['company'].get('name')
+        if org and not user.organization:
+            user.organization = org
+        if position.get('title') and not user.position:
+            user.position = position['title']
+
     if info.get('headline') and not user.position:
         user.position = info['headline']
 

--- a/app/tests/test_linkedin.py
+++ b/app/tests/test_linkedin.py
@@ -104,8 +104,26 @@ class LinkedinDbTests(DbTestCase):
         linkedin.store_access_token(self.user, FAKE_AUTHORIZED_RESPONSE)
         self.assertEqual(UserLinkedinInfo.query.count(), 1)
 
-    def test_headline_is_imported_from_profile(self):
+    def test_position_and_org_are_imported_from_profile(self):
         linkedin.update_user_fields_from_profile(self.user, {
+            u'positions': {
+                u'_total': 1,
+                u'values': [{u'company': {u'name': u'Self-Employed'},
+                             u'id': 768900354,
+                             u'isCurrent': True,
+                             u'location': {},
+                             u'startDate': {u'month': 7, u'year': 2015},
+                             u'summary': u'I currently freelance.',
+                             u'title': u'Tinkerer'}],
+            },
+            u'headline': 'Do not use this'
+        })
+        self.assertEqual(self.user.position, 'Tinkerer')
+        self.assertEqual(self.user.organization, 'Self-Employed')
+
+    def test_headline_is_imported_from_profile_when_position_is_empty(self):
+        linkedin.update_user_fields_from_profile(self.user, {
+            u'positions': {u'_total': 0},
             u'headline': 'Awesome Person'
         })
         self.assertEqual(self.user.position, 'Awesome Person')

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,9 @@ app:
         - .:/noi
         - ./migrations:/migrations
         - ./alchemydumps:/alchemydumps
+    entrypoint: python /noi/entrypoint.py
     environment:
+        HOST_USER: $USER
         NOI_ENVIRONMENT: development
 db:
     image: postgres:9.4

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -1,0 +1,41 @@
+#! /usr/bin/env python
+
+import sys
+import os
+import pwd
+import subprocess
+
+HOST_UID = os.stat('/noi').st_uid
+HOST_USER = os.environ.get('HOST_USER', 'code_executor_user')
+
+def does_username_exist(username):
+    try:
+        pwd.getpwnam(username)
+        return True
+    except KeyError:
+        return False
+
+def does_uid_exist(uid):
+    try:
+        pwd.getpwuid(uid)
+        return True
+    except KeyError:
+        return False
+
+if __name__ == '__main__':
+    if HOST_UID != os.geteuid():
+        if not does_uid_exist(HOST_UID):
+            username = HOST_USER
+            while does_username_exist(username):
+                username += '0'
+            home_dir = '/home/%s' % username
+            #print "Creating username %s with UID %d" % (username, HOST_UID)
+            subprocess.check_call([
+                'useradd',
+                '-d', home_dir,
+                '-m', username,
+                '-u', str(HOST_UID)
+            ])
+        os.environ['HOME'] = '/home/%s' % pwd.getpwuid(HOST_UID).pw_name
+        os.setuid(HOST_UID)
+    os.execvp(sys.argv[1], sys.argv[1:])


### PR DESCRIPTION
This fixes #275.

Note that existing deploys which don't already run as `root` on the host system will need to run the following from the root of their repository:

```bash
sudo chown -R $USER.$USER *
```

Or on OS X:

```bash
sudo chown -R $USER *
```
