### PR TITLE
Add pytest integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ translate.tmp.html
 gen/
 .DS_Store
 docker-compose.override.yml
+.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
 
 script:
   - docker-compose pull
-  - ./nosetests.sh
+  - docker-compose run app py.test
 
 notifications:
   slack: govlab:FhXXpjcwabyHAV35OjQeKFTR

--- a/README.md
+++ b/README.md
@@ -118,11 +118,11 @@ control.
 
 ### Unit Testing
 
-To run the unit tests, simply run:
+To run the unit tests, run:
 
-    ./nosetests.sh
+    docker-compose run app py.test
 
-This just executes [`nosetests`][] inside the web application's Docker
+This just executes [`py.test`][] inside the web application's Docker
 container.
 
 Tests are located in `app/tests`. Please feel free to add more!
@@ -194,7 +194,7 @@ For more details on how we write our SASS, see the project's
 
   [git-lfs]: https://git-lfs.github.com/
   [packagecloud]: https://packagecloud.io/github/git-lfs/install
-  [`nosetests`]: https://nose.readthedocs.org/en/latest/usage.html
+  [`py.test`]: http://pytest.org/latest/usage.html
   [Docker Toolbox]: https://www.docker.com/toolbox
   [Build Details]: https://hub.docker.com/r/thegovlab/noi2/builds/
   [SASS]: http://sass-lang.com/

--- a/app/docker-quick/Dockerfile
+++ b/app/docker-quick/Dockerfile
@@ -9,3 +9,6 @@ MAINTAINER Atul Varma <atul@thegovlab.org>
 
 COPY requirements.quick.txt /noi/app/
 RUN pip install --upgrade -r /noi/app/requirements.quick.txt
+
+# http://stackoverflow.com/a/16745106/2422398
+RUN /usr/bin/yes | pip uninstall nose

--- a/app/docker-quick/requirements.quick.txt
+++ b/app/docker-quick/requirements.quick.txt
@@ -3,3 +3,7 @@ bleach==1.4.2
 Flask-OAuthlib==0.9.2
 mock==1.3.0
 pytest==2.8.7
+
+# REMINDER: We have *removed* nose in favor of pytest and are manually
+# running `pip uninstall` in the quick Dockerfile. Make sure that we
+# remove nose in app/requirements.txt when creating docker-base-0.3.

--- a/app/docker-quick/requirements.quick.txt
+++ b/app/docker-quick/requirements.quick.txt
@@ -2,3 +2,4 @@ feedparser==5.2.1
 bleach==1.4.2
 Flask-OAuthlib==0.9.2
 mock==1.3.0
+pytest==2.8.7

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -1,0 +1,18 @@
+import pytest
+
+from .test_models import (wait_until_db_is_ready,
+                          db_test_request_context,
+                          create_tables,
+                          drop_tables)
+
+@pytest.fixture(scope="session", autouse=True)
+def create_db_tables(request):
+    wait_until_db_is_ready()
+    with db_test_request_context():
+        create_tables()
+
+    def teardown():
+        with db_test_request_context():
+            drop_tables()
+
+    request.addfinalizer(teardown)

--- a/app/tests/test_l10n.py
+++ b/app/tests/test_l10n.py
@@ -3,9 +3,9 @@ from babel.messages.pofile import read_po
 from babel.messages.catalog import TranslationError, Message
 from babel.messages import checkers
 from flask import Flask
-from nose.tools import eq_
 
 from .test_views import ViewTestCase
+from .util import eq_
 from app import l10n
 
 def test_flask_security_strings_do_not_interpolate():

--- a/app/tests/test_models.py
+++ b/app/tests/test_models.py
@@ -3,13 +3,13 @@ import StringIO
 import contextlib
 from flask import Flask
 from flask_testing import TestCase
-from nose.tools import eq_
 from sqlalchemy import create_engine
 from sqlalchemy.exc import OperationalError, IntegrityError
 from sqlalchemy_utils import Country
 from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
 import psycopg2
 
+from .util import eq_
 from .factories import UserFactory, UserSkillFactory
 from .. import models, LEVELS, babel
 

--- a/app/tests/util.py
+++ b/app/tests/util.py
@@ -1,0 +1,9 @@
+# Taken from nose:
+#
+# https://github.com/nose-devs/nose/blob/master/nose/tools/trivial.py
+
+def eq_(a, b, msg=None):
+    """Shorthand for 'assert a == b, "%r != %r" % (a, b)
+    """
+    if not a == b:
+        raise AssertionError(msg or "%r != %r" % (a, b))

--- a/nosetests.sh
+++ b/nosetests.sh
@@ -1,3 +1,0 @@
-#!/bin/bash -e
-
-docker-compose run --service-ports app nosetests --with-doctest -I manage.py -I wsgi.py $@

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+addopts = --doctest-modules
+norecursedirs = migrations app/noi1
+


### PR DESCRIPTION
I just noticed this [note to users](https://nose.readthedocs.org/en/latest/#note-to-users) in the nose docs:

> Nose has been in maintenance mode for the past several years and will likely cease without a new person/team to take over maintainership. New projects should consider using Nose2, py.test, or just plain unittest/unittest2.

So we might want to migrate to py.test since it seems to have the closest feature parity with nose.

To do:
- [X] Figure out why py.test finds 188 tests, while nosetest finds 191. :worried: 
  * It looks like nose is running our `db_test_request_context` helper function *three times*! Lame.
- [x] Remove nosetest package via our `docker-quick/Dockerfile` and make sure everything still works.
- [x] Change readme to mention `py.test` instead of `nosetests` or `nosetests.sh`.
- [x] Change `.travis.yml` to run `py.test` instead of `nosetests.sh`.
