### PR TITLE
Add support for optional email confirmation.

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -19,10 +19,16 @@ SECURITY_CHANGEABLE: True
 SECURITY_PASSWORD_HASH: bcrypt
 SECURITY_PASSWORD_SALT: 'bb83d6fa8d0a4adc'
 SECURITY_SEND_REGISTER_EMAIL: False
+SECURITY_CONFIRMABLE: True
+SECURITY_LOGIN_WITHOUT_CONFIRMATION: True
+
+# This is a workaround for
+# https://github.com/mattupstate/flask-security/pull/489.
+SECURITY_MSG_CONFIRM_REGISTRATION: ['DO_NOT_DISPLAY_ME', 'success']
 
 SECURITY_EMAIL_SENDER: noreply@networkofinnovators.org
 SECURITY_POST_REGISTER_VIEW: 'views.register_step_2'
-SECURITY_POST_CONFIRM_VIEW: 'views.register_step_2'
+SECURITY_POST_CONFIRM_VIEW: 'views.confirmation_success'
 SECURITY_POST_LOGIN_VIEW: 'views.activity'
 SECURITY_EMAIL_SUBJECT_REGISTER: 'Welcome to the Network of Innovators!'
 SECURITY_EMAIL_SUBJECT_PASSWORD_NOTICE: 'Your Network of Innovators password has been reset'

--- a/app/factory.py
+++ b/app/factory.py
@@ -17,7 +17,7 @@ from app import (csrf, cache, mail, bcrypt, s3, assets, security, admin,
                  QUESTIONS_BY_ID, LEVELS_BY_SCORE, QUESTIONNAIRES_BY_ID)
 from app.forms import (NOIForgotPasswordForm, NOILoginForm,
                        NOIResetPasswordForm, NOIChangePasswordForm,
-                       NOIRegisterForm)
+                       NOIConfirmRegisterForm, NOISendConfirmationForm)
 from app.models import db, User, Role
 from app.views import views
 from app.utils import get_nopic_avatar
@@ -81,9 +81,6 @@ def create_app(config=None): #pylint: disable=too-many-statements
     else:
         app.config.update(config)
 
-    # Confirming email is currently unsupported.
-    app.config['SECURITY_CONFIRMABLE'] = False
-
     with open('/noi/app/data/deployments.yaml') as deployments_yaml:
         deployments = yaml.load(deployments_yaml)
 
@@ -118,10 +115,11 @@ def create_app(config=None): #pylint: disable=too-many-statements
     user_datastore = DeploySQLAlchemyUserDatastore(db, User, Role)
     security.init_app(app, datastore=user_datastore,
                       login_form=NOILoginForm,
-                      register_form=NOIRegisterForm,
+                      confirm_register_form=NOIConfirmRegisterForm,
                       forgot_password_form=NOIForgotPasswordForm,
                       reset_password_form=NOIResetPasswordForm,
-                      change_password_form=NOIChangePasswordForm)
+                      change_password_form=NOIChangePasswordForm,
+                      send_confirmation_form=NOISendConfirmationForm)
 
     db.init_app(app)
     alchemydumps.init_app(app, db)

--- a/app/forms.py
+++ b/app/forms.py
@@ -9,9 +9,10 @@ from flask import current_app
 from flask.ext.babel import get_locale
 from flask_wtf import Form
 from flask_wtf.file import FileField, FileAllowed
-from flask_security.forms import (LoginForm, RegisterForm,
+from flask_security.forms import (LoginForm, ConfirmRegisterForm,
                                   ForgotPasswordForm, ChangePasswordForm,
                                   ResetPasswordForm,
+                                  SendConfirmationForm,
                                   email_required,
                                   email_validator, unique_user_email,
                                   valid_user_email,
@@ -213,6 +214,13 @@ class ChangeLocaleForm(Form):
     )
 
 
+class NOISendConfirmationForm(SendConfirmationForm):
+    '''
+    Localizeable version of Flask-Security's SendConfirmationForm
+    '''
+    submit = SubmitField(lazy_gettext('Resend Confirmation Instructions'))
+
+
 class NOIForgotPasswordForm(ForgotPasswordForm):
     '''
     Localizeable version of Flask-Security's ForgotPasswordForm
@@ -233,9 +241,9 @@ class NOILoginForm(LoginForm):
     submit = SubmitField(lazy_gettext('Log in'))
 
 
-class NOIRegisterForm(RegisterForm):
+class NOIConfirmRegisterForm(ConfirmRegisterForm):
     '''
-    Localizeable version of Flask-Security's RegisterForm
+    Localizeable version of Flask-Security's ConfirmRegisterForm
     '''
 
     # Note that extra fields in this registration form are passed
@@ -254,7 +262,6 @@ class NOIRegisterForm(RegisterForm):
     password = PasswordField(
         lazy_gettext('Password'), validators=[password_required,
                                               password_length])
-    password_confirm = None
     submit = SubmitField(lazy_gettext('Sign up'))
 
 

--- a/app/l10n.py
+++ b/app/l10n.py
@@ -30,6 +30,12 @@ def configure_app(app):
 
     app.config['SECURITY_MSG_UNAUTHORIZED'] = (
         lazy_gettext('You do not have permission to view this resource.'), 'error')
+    app.config['SECURITY_MSG_EMAIL_CONFIRMED'] = (
+        lazy_gettext('Thank you. Your email has been confirmed.'), 'success')
+    app.config['SECURITY_MSG_ALREADY_CONFIRMED'] = (
+        lazy_gettext('Your email has already been confirmed.'), 'info')
+    app.config['SECURITY_MSG_INVALID_CONFIRMATION_TOKEN'] = (
+        lazy_gettext('Invalid confirmation token.'), 'error')
     app.config['SECURITY_MSG_EMAIL_ALREADY_ASSOCIATED'] = (
         lazy_gettext('%(email)s is already associated with an account.'), 'error')
     app.config['SECURITY_MSG_PASSWORD_MISMATCH'] = (
@@ -45,6 +51,14 @@ def configure_app(app):
                      'instructions have been sent to %(email)s.'), 'error')
     app.config['SECURITY_MSG_INVALID_RESET_PASSWORD_TOKEN'] = (
         lazy_gettext('Invalid reset password token.'), 'error')
+    app.config['SECURITY_MSG_CONFIRMATION_REQUIRED'] = (
+        lazy_gettext('Email requires confirmation.'), 'error')
+    app.config['SECURITY_MSG_CONFIRMATION_REQUEST'] = (
+        lazy_gettext('Confirmation instructions have been sent to %(email)s.'), 'info')
+    app.config['SECURITY_MSG_CONFIRMATION_EXPIRED'] = (
+        lazy_gettext('You did not confirm your email within %(within)s. New '
+                     'instructions to confirm your email have been sent to '
+                     '%(email)s.'), 'error')
     app.config['SECURITY_MSG_LOGIN_EXPIRED'] = (
         lazy_gettext('You did not login within %(within)s. New instructions to '
                      'login have been sent to %(email)s.'), 'error')

--- a/app/templates/__base_new__.html
+++ b/app/templates/__base_new__.html
@@ -27,7 +27,13 @@
 
 {% from "_macros.html" import render_alert %}
 {% for category, message in get_flashed_messages(with_categories=true) %}
+  {# Some flashed messages come from third-party code and we don't want
+     them to be displayed. The only way we can disable them from being
+     displayed, unfortunately, is to set their message text to something
+     we detect for here. #}
+  {%- if message != 'DO_NOT_DISPLAY_ME' -%}
   {{ render_alert(message=message, category=category) }}
+  {%- endif -%}
 {% endfor %}
 
     {% block header %}{% endblock %}

--- a/app/templates/security/_menu_new.html
+++ b/app/templates/security/_menu_new.html
@@ -5,8 +5,5 @@
   {% if security.recoverable %}
   <li><a href="{{ url_for_security('forgot_password') }}">{{ gettext('Forgot password') }}</a><br/></li>
   {% endif %}
-  {% if security.confirmable %}
-  <li><a href="{{ url_for_security('send_confirmation') }}">{{ gettext('Confirm account') }}</a></li>
-  {% endif %}
 </ul>
 {% endif %}

--- a/app/templates/security/send_confirmation.html
+++ b/app/templates/security/send_confirmation.html
@@ -1,0 +1,24 @@
+{% extends '__base_new__.html' %}
+
+{% block title %}{{ gettext('Send confirmation instructions') }}{% endblock %}
+
+{% from "security/_macros_new.html" import render_field_with_errors, render_field %}
+
+{% block content %}
+<div class="b-onboarding">
+    <header>
+        <div class="b-logo"></div>
+    </header>
+
+    <section>
+        <p class="e-onboarding-message">{{ gettext('Send confirmation instructions') }}</p>
+        <form action="{{ url_for_security('send_confirmation') }}" method="POST" name="send_confirmation_form" class="e-onboarding-form">
+            {{ send_confirmation_form.hidden_tag() }}
+            {{ render_field_with_errors(send_confirmation_form.email) }}
+      {{ send_confirmation_form.submit(class="b-button") }}
+  </form>
+    </section>
+    {% include "security/_menu_new.html" %}
+</div>
+
+{% endblock %}

--- a/app/tests/test_views.py
+++ b/app/tests/test_views.py
@@ -1,8 +1,10 @@
+import re
 import logging
 from StringIO import StringIO
 from urllib import urlencode
 from moto import mock_s3
 import boto
+from flask import url_for
 from flask_login import current_user
 
 from app import (QUESTIONS_BY_ID, MIN_QUESTIONS_TO_JOIN, LEVELS,
@@ -103,7 +105,8 @@ class ViewTestCase(DbTestCase):
         self.assertRedirects(method(path),
                              '/login?%s' % urlencode({'next': path}))
 
-class InviteTests(ViewTestCase):
+
+class EmailTestCase(ViewTestCase):
     BASE_APP_CONFIG = ViewTestCase.BASE_APP_CONFIG.copy()
 
     BASE_APP_CONFIG.update(
@@ -112,6 +115,8 @@ class InviteTests(ViewTestCase):
         MAIL_SUPPRESS_SEND=True,
     )
 
+
+class InviteTests(EmailTestCase):
     def setUp(self):
         super(ViewTestCase, self).setUp()
         self.login()
@@ -637,7 +642,48 @@ class UploadPictureTests(ViewTestCase):
         self.assertEqual(key.content_type, 'image/png')
 
 
+class EmailConfirmationTests(EmailTestCase):
+    def test_confirmation_works(self):
+        self.register_and_login('foo@example.org', 'test123')
+
+        with mail.record_messages() as outbox:
+            res = self.client.post('/confirm', data=dict(
+                email=u'foo@example.org'
+            ))
+            self.assertEqual(len(outbox), 1)
+            msg = outbox[0]
+            self.assertEqual(msg.sender, 'noreply@networkofinnovators.org')
+            self.assertEqual(msg.recipients, ['foo@example.org'])
+            assert 'http://localhost/confirm/' in msg.body
+            assert ('Confirmation instructions have been '
+                    'sent to foo@example.org') in res.data
+
+        token = re.search(
+            r'http:\/\/localhost\/confirm\/(.+)',
+            msg.body,
+            flags=re.MULTILINE
+        ).group(1)
+
+        res = self.client.get('/confirm/%s' % token)
+        self.assertRedirects(res, '/confirm/success')
+
+        res = self.client.get('/confirm/success')
+        self.assertRedirects(res, '/activity')
+
+        res = self.client.get('/activity')
+        self.assert200(res)
+        assert 'Your email has been confirmed' in res.data
+
 class ViewTests(ViewTestCase):
+    def test_security_post_views_exist(self):
+        view_names = [
+            self.app.config['SECURITY_POST_REGISTER_VIEW'],
+            self.app.config['SECURITY_POST_CONFIRM_VIEW'],
+            self.app.config['SECURITY_POST_LOGIN_VIEW'],
+        ]
+        for view_name in view_names:
+            url_for(view_name)
+
     def test_main_page_is_ok(self):
         self.assert200(self.client.get('/'))
 

--- a/app/views.py
+++ b/app/views.py
@@ -295,6 +295,14 @@ def register_step_2():
     return render_template('register-step-2.html', form=form)
 
 
+@views.route('/confirm/success')
+@login_required
+def confirmation_success():
+    # In the future, we can make this view redirect the user to
+    # whatever they wanted to do that required confirmation.
+    return redirect(url_for('views.activity'))
+
+
 def render_user_profile(userid=None, **kwargs):
     if userid is None:
         user = current_user


### PR DESCRIPTION
This is a prerequisite for Discourse integration (#280).

Note that confirmation once existed as a *required* activity for some NoI deploys, but was removed in 5edab516e82f0bb0e4dcde4b95bde4b23bfa7541. This PR brings back some of that code.

This PR also contains a workaround for https://github.com/mattupstate/flask-security/pull/489.

Stuff to do:

- [x] ~~It's weird that we have the `SECURITY_EMAIL_SENDER` set to `noreply@networkofinnovators.org`, which is configured entirely separately from other emails sent by the app, e.g. the "invite a user" feature which uses `MAIL_USERNAME` or something. Might want to consolidate this configuration, either in this PR or a separate issue.~~ Filed #285 for this.
