### PR TITLE
[WIP] Linkifying User Inputted Text 

### DIFF
--- a/app/templates/_activity_events.html
+++ b/app/templates/_activity_events.html
@@ -8,7 +8,7 @@
     {{ user_avatar(event.user) }}
     <div class="e-feed-message">
       <p>{{ gettext('%(user)s shared:', user=user_link(event.user)) }}</p>
-      <p>{{ event.message }}</p>
+      <p>{{ event.message | urlize }}</p>
       {% if current_user.is_authenticated() %}
       <div class="e-actions">
         {% call render_user_mailto_link(event.user) %}<span class="material-icons">reply</span> <span class="e-action-label">{{ gettext("Reply via e-mail") }}</span>{% endcall %}

--- a/app/tests/test_views.py
+++ b/app/tests/test_views.py
@@ -236,16 +236,12 @@ class MultiStepRegistrationTests(ViewTestCase):
 class ActivityFeedTests(ViewTestCase):
     def test_activity_link_present(self):
         self.login()
-        user = User.query_in_deployment()\
-                 .filter(User.email == 'test@example.org').one()
-        user.first_name = 'John'
-        user.last_name = 'Doe'
         self.client.post('/activity', data=dict(
             message=u"hello there. Please check out, http://freecodecamp.com"
         ), follow_redirects=True)
         res = self.client.get('/activity')
         assert 'href="http://freecodecamp.com"' in res.data
-        
+
     def test_get_is_ok(self):
         self.assert200(self.client.get('/activity'))
 

--- a/app/tests/test_views.py
+++ b/app/tests/test_views.py
@@ -234,6 +234,18 @@ class MultiStepRegistrationTests(ViewTestCase):
         self.assert404(self.client.get('/register/step/3/blah/1'))
 
 class ActivityFeedTests(ViewTestCase):
+    def test_activity_link_present(self):
+        self.login()
+        user = User.query_in_deployment()\
+                 .filter(User.email == 'test@example.org').one()
+        user.first_name = 'John'
+        user.last_name = 'Doe'
+        self.client.post('/activity', data=dict(
+            message=u"hello there. Please check out, http://freecodecamp.com"
+        ), follow_redirects=True)
+        res = self.client.get('/activity')
+        assert 'href="http://freecodecamp.com"' in res.data
+        
     def test_get_is_ok(self):
         self.assert200(self.client.get('/activity'))
 


### PR DESCRIPTION
I'm labelling this as WIP because it doesn't catch edge cases. It works for every instance that the full url is given, but doesn't catch cases like: 

bit.ly/citizensengage

One potential solution may be using regex for edge cases?