### PR TITLE
[WIP] Add a custom 404 page.

### DIFF
--- a/app/error_handlers.py
+++ b/app/error_handlers.py
@@ -1,0 +1,8 @@
+import flask
+from flask import Blueprint, render_template
+
+blueprint = flask.Blueprint('error_handlers', __name__)
+
+@blueprint.app_errorhandler(404)
+def page_not_found(e):
+    return render_template('404.html'), 404

--- a/app/factory.py
+++ b/app/factory.py
@@ -12,7 +12,7 @@ from werkzeug.contrib.fixers import ProxyFix
 
 from app import (csrf, cache, mail, bcrypt, s3, assets, security, admin,
                  babel, alchemydumps, sass, email_errors, csp, oauth,
-                 linkedin, discourse,
+                 linkedin, discourse, error_handlers,
                  QUESTIONNAIRES, NOI_COLORS, LEVELS, ORG_TYPES,
                  QUESTIONS_BY_ID, LEVELS_BY_SCORE, QUESTIONNAIRES_BY_ID)
 from app.forms import (NOIForgotPasswordForm, NOILoginForm,
@@ -89,6 +89,7 @@ def create_app(config=None): #pylint: disable=too-many-statements
 
     l10n.configure_app(app)
 
+    app.register_blueprint(error_handlers.blueprint)
     app.register_blueprint(views)
     if app.config['DEBUG']:
         app.register_blueprint(style_guide.views)

--- a/app/static/sass/_error-page.scss
+++ b/app/static/sass/_error-page.scss
@@ -1,0 +1,20 @@
+.e-error-display {
+  background-color: $blue;
+  text-align: center;
+  text-transform: uppercase;
+  padding-top: 4em;
+  h2,h3,h4 {
+    color: $white-80;;
+    padding: .5em;
+  }
+}
+
+.error-page-icon { 
+  color: $white-80;;
+  font-size: 4em;
+   }
+
+.e-error-display a {
+  color: $white-90;
+  font-weight: bold;
+}

--- a/app/static/sass/styles.scss
+++ b/app/static/sass/styles.scss
@@ -96,6 +96,8 @@ body {
 
 @import 'desktop-hack';
 
+@import 'error-page';
+
 /* Useful for making blocks of content that we don't have time to style
  * not look utterly unstyled and horrible. */
 .b-temporary-styling {

--- a/app/templates/404.html
+++ b/app/templates/404.html
@@ -1,0 +1,15 @@
+{% extends '__base_ui__.html' %}
+
+{% block title %}Page Not Found | Network of Innovators{% endblock %}
+{% block body_class %}b-landing-page{% endblock %}
+
+{% block content %}
+  <section class="b-homepage-panel e-error-display"> 
+    <div class='row'>
+      <i class="material-icons error-page-icon">error_outline</i>
+      <h2>Error 404</h2>
+      <h3>We couldn't find what you were looking for</h3>
+      <h4>Try using the navigation above or click <a href="/">here</a> to go back to the homepage</h4>
+    </div>
+  </section>
+{% endblock %}


### PR DESCRIPTION
This contains @tekd's #282 with a simplified commit history:

![2016-03-16_16-27-47](https://cloud.githubusercontent.com/assets/124687/13827630/0cc9fcc0-eb94-11e5-9609-01ba0d8a790b.png)

We also need to do a few things before merging it:

- [ ] Run the copy by Batu.
- [ ] Consider changing the "click here to go back to the homepage" as [hyperlinking words like "here" isn't good for accessibility](http://webaim.org/techniques/hypertext/#screen_readers). Suggestion: just hyperlink "go back to the homepage" instead, and remove the words "click here" entirely.
- [ ] Add support for internationalization.
